### PR TITLE
Document Codex Micro reverse engineering

### DIFF
--- a/public/docs/README.md
+++ b/public/docs/README.md
@@ -1,14 +1,21 @@
 # Agent Controller 公开设计索引
 
-这里提供面向使用者和贡献者的简要设计入口。它描述产品合同、输入映射和当前观测到的 Codex Micro 协议；不以单元测试代替真实 Codex + 实体手柄验收。
+这里提供面向使用者和贡献者的设计入口。资料按“系统—操作—界面—协议—验证”分层，避免把产品合同、历史实现和私有协议证据混在同一张表中；单元测试也不能替代真实 Codex + 实体手柄验收。
 
-- [架构与输入链路](architecture-and-input-flow.md)：手柄、Micro 设备平面、Codex 接收链路，以及驱动依赖结论。
-- [手柄操作列表](controller-operations.md)：基础层、组合层和安全规则。
-- [Codex Micro 指令参考](codex-micro-command-reference.md)：`ENC_CW`、`ENC_CC`、`ACT*`、`AG*`、RPC 与 64-byte report。
+## 当前设计合同
 
-更详细或偏实现的材料：
+| 资料 | 内容 |
+| --- | --- |
+| [系统设计、UML 与指令映射](system-design-and-command-map.md) | 系统上下文、核心类、状态机、Action ID、执行器、物理输入到 wire 的总映射 |
+| [手柄操作列表](controller-operations.md) | Base、Y、LB/RB/RT 层和安全规则；面向使用者的操作事实源 |
+| [界面与交互设计](interface-design.md) | 主窗口信息架构、Overlay 家族、状态、反馈、主题、无障碍与验收清单 |
+| [架构与输入链路](architecture-and-input-flow.md) | 手柄、Micro 设备平面、Broker、驱动、Codex 接收链路与依赖结论 |
+| [Codex Micro 实体键盘接入、逆向证据与 UML](codex-micro-physical-connection.md) | USB/Bluetooth、vendor HID、build 指纹、wire/RPC、只读复现，以及实体与虚拟 Micro 的边界 |
+| [Codex Micro 指令参考](codex-micro-command-reference.md) | `ENC_CW`、`ENC_CC`、`ACT*`、`AG*`、RPC 与 64-byte report |
 
-- [v0.7 当前手柄指令清单](controller-command-reference-v0.7.md)
+## 历史、证据与验收
+
+- [v0.7 手柄指令清单](controller-command-reference-v0.7.md)：仅用于追踪旧实现与规范差异，不作为最新合同。
 - [Codex Micro VHF/状态/输入协议证据](../../docs/codex-26.707.12708-vhf-status-input.zh-CN.md)
 - [ADR-0002：原生 Micro 兼容决策](../../docs/adr/0002-codex-micro-native-compatibility.zh-CN.md)
 - [控制器输入已知问题与实机复现](../../todo/91-controller-input-known-issues.md)

--- a/public/docs/codex-micro-physical-connection.md
+++ b/public/docs/codex-micro-physical-connection.md
@@ -1,0 +1,308 @@
+# Codex Micro 实体键盘接入与 UML
+
+> Status: Official setup + read-only reverse-engineering evidence + private compatibility boundary
+>
+> Updated: 2026-07-19
+> Scope: 实体 Codex Micro；不把 Agent Controller 的虚拟 VHF 设备当成实体连接方式
+
+## 1. 结论
+
+实体 Codex Micro **直接连接电脑，不经过 Agent Controller**：
+
+1. 通过 **USB-C 数据线**或 **Bluetooth** 连接电脑；
+2. 有线 Codex 通道由操作系统识别为 **vendor-defined HID**；
+3. ChatGPT 桌面应用检测到 Codex Micro，首次连接时显示设置流程；
+4. ChatGPT 在 Codex Micro 的 **layer 1** 上接收 Agent Key、Command Key、摇杆和旋钮输入，并向设备更新灯光；
+5. 用户在 **Settings > Codex Micro** 中配置六个 Agent 槽、Command Key、Analog 方向、旋钮模式与灯光。
+
+这是[官方 Codex Micro 指南](https://learn.chatgpt.com/docs/features/codex-micro)公开的支持边界。官方文档没有把底层 HID/RPC 字节合同承诺为公共 API；本仓库记录的 `v.oai.hid`、`v.oai.rad`、64-byte report 和 bridge 名称只属于特定 Codex Desktop build 的兼容观测。
+
+### 1.1 到底是不是 USB HID
+
+**有线 Codex 专用通道是 USB HID，但不是普通键盘 HID。** 对 Codex Desktop 26.707/26.715 的本地只读观测显示：
+
+| 字段 | 观测值 | 含义 |
+| --- | --- | --- |
+| VID / PID | `0x303A / 0x8360` | Codex Micro 设备身份 |
+| Usage Page / Usage | `0xFF00 / 0x0001` | vendor-defined HID collection；不是 Keyboard Usage Page `0x07` |
+| Report ID | `0x06` | Codex 双向 report |
+| Report 长度 | 64 bytes | 含 Report ID；其余为 channel、长度与 UTF-8 payload |
+| Device → ChatGPT | HID Input Report | `v.oai.hid` 按键、`v.oai.rad` 摇杆、RPC response |
+| ChatGPT → Device | HID Output Report | 灯光、槽位状态、版本和设备状态 RPC |
+
+也就是说，Codex 的按键不是作为普通 USB 键盘扫描码直接交给 ChatGPT；它把 JSON 消息分片装进 vendor HID report，由 ChatGPT 的 Micro 集成解释。设备的其他 Work Louder layer 可以有普通快捷键行为，但那不是这里描述的 Codex layer 1 私有通道。
+
+Bluetooth 方面，官方只承诺“可以通过 Bluetooth 连接”。从应用角度，它最终仍由操作系统作为输入/HID 类设备提供给 ChatGPT；**究竟是 BLE HID over GATT 还是 Bluetooth Classic HID，当前官方文档和本仓库证据都没有冻结，不能写死。**
+
+## 2. 部署 UML
+
+```mermaid
+flowchart LR
+    User["用户"]
+    Micro["Codex Micro 实体设备<br/>firmware / layer 1"]
+    Link{"USB-C 或 Bluetooth"}
+    OS["Windows / macOS<br/>USB、Bluetooth 与 HID 设备栈"]
+    ChatGPT["ChatGPT Desktop"]
+    Integration["Codex Micro integration<br/>检测、映射、RPC 与灯光"]
+    UI["Chats / Composer / Approval / Skills"]
+    Settings["Settings > Codex Micro"]
+    Mic["电脑麦克风"]
+
+    User -->|按键、旋钮、摇杆| Micro
+    Micro <-->|USB vendor HID 或无线配对| Link
+    Link <-->|设备输入、状态与灯光数据| OS
+    OS <-->|HID/设备检测与双向 report| ChatGPT
+    ChatGPT --> Integration
+    Settings -->|Agent/Command/Analog/Dial/Lighting 配置| Integration
+    Integration -->|执行当前 layer 1 映射| UI
+    UI -->|chat/turn 状态| Integration
+    Integration -->|槽位灯光与设备配置| Micro
+    Micro -->|电池等设备状态（设备支持时）| Integration
+    Mic -->|PTT 音频| ChatGPT
+```
+
+图中的 “Codex Micro integration” 是公开行为的逻辑组件名，不代表官方承诺了可供第三方调用的独立 SDK 或稳定进程接口。
+
+## 3. 首次连接时序 UML
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor User as 用户
+    participant Micro as Codex Micro
+    participant OS as Windows / macOS
+    participant App as ChatGPT Desktop
+    participant Settings as Codex Micro Settings
+
+    User->>App: 打开 ChatGPT 桌面应用
+    User->>Micro: 接入 USB-C 或进入 Bluetooth 配对
+    Micro->>OS: 枚举/配对为输入设备
+    OS-->>App: 设备可用
+    App->>App: 首次检测 Codex Micro
+
+    alt macOS 且尚未授权
+        App-->>User: 请求 Input Monitoring
+        User->>OS: 允许 ChatGPT 监控输入
+        User->>App: 退出并重新打开应用
+    end
+
+    App-->>User: 显示 Codex Micro 设置流程
+    User->>Settings: 选择 Agent source、Command、Analog、Dial 与灯光
+    Settings->>App: 保存 layer 1 映射
+    App-->>Micro: 应用灯光/状态配置
+```
+
+在 macOS 上，ChatGPT 需要 **Input Monitoring** 权限才能响应实体键盘按键；Windows 的官方设置步骤没有这一项。
+
+## 4. 按键执行时序 UML
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor User as 用户
+    participant Micro as Codex Micro firmware
+    participant OS as OS input/device stack
+    participant Service as ChatGPT Codex Micro integration
+    participant UI as Chat / Composer UI
+
+    User->>Micro: 按下 Agent / Command Key
+    Micro->>OS: 输入事件或设备 report
+    OS->>Service: 转交设备输入
+    Service->>Service: 读取 layer 1 当前映射与上下文
+
+    alt Agent Key
+        Service->>UI: 切换/聚焦绑定的 chat
+        UI-->>Service: Idle / Thinking / Complete / Requires input / Error
+        Service-->>Micro: 更新对应 Agent Key 灯光
+    else Command Key
+        Service->>UI: Fast / Approve / Decline / Fork / PTT / Submit 或自定义动作
+        UI-->>Service: 可见状态变化
+    else Dial / Analog
+        Service->>UI: Composer 导航、Reasoning 或已配置方向动作
+        UI-->>Service: 当前焦点/菜单状态
+    end
+
+    User->>Micro: 松开按键或让 Analog 回中
+    Micro->>OS: release / neutral
+    OS->>Service: 结束 held state
+```
+
+官方文档公开的是上面的行为语义。`codex-micro-service`、`codex-micro-bridge`、`AG*`、`ACT*`、`ENC*` 等名字来自本仓库对特定桌面版本的只读观测，可能随 ChatGPT Desktop 更新而变化。
+
+## 5. 逆向证据链与复现方法
+
+本节只描述对本机已安装 ChatGPT Desktop 包体、设备枚举和本仓库虚拟设备回环的**只读兼容性研究**。它不修改 `app.asar`，不绕过访问控制，不提取或改写实体设备固件，也不把私有协议宣称为官方 SDK。
+
+### 5.1 证据分层
+
+| 层级 | 来源 | 可以证明 | 不能证明 |
+| --- | --- | --- | --- |
+| 官方产品说明 | Codex Micro 使用指南 | USB-C/Bluetooth、layer 1、可配置行为、灯光和 macOS Input Monitoring | HID descriptor、消息格式、进程和稳定 ABI |
+| 安装包静态观测 | 已安装 ChatGPT Desktop 的 service、renderer 与 Work Louder 依赖 | 目标 build 的设备筛选、消息名、布局和状态转换 | 未来 build 仍保持相同实现 |
+| HID/wire 观测 | VID/PID、Usage、Report ID、Input/Output report | 目标 build 期待的 vendor HID 形状和双向 framing | transport ACK 等于业务成功 |
+| 虚拟设备回环 | `virtual-micro` + VHF + 真实 ChatGPT Desktop | 相同 descriptor/report 能被目标 build 识别并驱动可见行为 | 第三方有权公开发行同一设备身份 |
+| 实体设备抓取 | 零售 Codex Micro 的 descriptor、USB/Bluetooth trace | 实体固件实际暴露的接口与无线 profile | 官方会长期兼容第三方实现 |
+
+当前仓库已经完成安装包静态观测和 Windows 虚拟 HID 回环；零售实体设备的独立 descriptor/无线 profile 抓取仍应作为单独证据归档。因此更严谨的说法是：**目标 ChatGPT build 的 Codex 专用通道已确认是 vendor-defined HID；实体零售设备应使用同一合同，但仍需独立抓取完成最终交叉验证。**
+
+### 5.2 冻结的目标 build 指纹
+
+以下 SHA-256 来自 `OpenAI.Codex_26.707.12708.0_x64__2p2nqsd0c76g0` 的只读解包，用于判断研究结论是否还能应用，不能视为文件签名或发布授权：
+
+| 包内文件 | SHA-256 |
+| --- | --- |
+| `.vite/build/codex-micro-service-CR6sUcZG.js` | `0bb261e3eed89ff69384754ab67df49c9f10dbd2fa567104c5859f43d026c911` |
+| `webview/assets/codex-micro-slot-signals-SFcKxWqG.js` | `e5f0084a27fc0e908c4514a5d3bd0a90dba3f953a48521fb4ae2a43b1e5b28bb` |
+| `webview/assets/codex-micro-bridge-D90_rd6W.js` | `df6063eb17046594e769050c6bbb3ed169b1352bbd5867fffb4d1f8c724f3e93` |
+| `@worklouder/device-kit-oai/dist/rpc_api_oai/rpc_api_oai.js` | `80815366885246cd9644e13b770f38c7f9c0587db13cc8979310571ba0fa029a` |
+| `@worklouder/device-kit-oai/node_modules/@worklouder/wl-device-kit/dist/index.js` | `f44d8d09e10a4608bf37f2860cd4807c3be9b0242f91d8258df540e277cd7548` |
+
+对应依赖版本为 `@worklouder/device-kit-oai 0.1.10` 与 `@worklouder/wl-device-kit 0.1.18`。26.715 的行为验证必须保存自己的 build、文件名和散列，不能继承 26.707 的指纹。
+
+### 5.3 逆向得到的组件关系
+
+```mermaid
+flowchart LR
+    Device["实体或兼容 Micro HID"]
+    HID["OS HID stack<br/>vendor page FF00 / report 06"]
+    Kit["Work Louder device-kit"]
+    Service["codex-micro-service<br/>枚举、framing、RPC、灯光"]
+    Bridge["codex-micro-bridge<br/>renderer 上下文映射"]
+    Slots["codex-micro-slot-signals<br/>Agent 槽状态"]
+    UI["Chat / Composer / Approval / Skills"]
+    Config["Codex Micro layout 与设置"]
+
+    Device <-->|Input / Output report| HID
+    HID <--> Kit
+    Kit <--> Service
+    Service <--> Bridge
+    Bridge <--> UI
+    UI --> Slots
+    Slots -->|槽位灯光模型| Service
+    Config --> Service
+    Config --> Bridge
+```
+
+这是对特定 bundle 的逻辑分层，不承诺每个框都是独立 OS 进程。稳定产品边界只能写成“ChatGPT Desktop 检测并控制 Codex Micro”；内部 chunk 名和依赖属于兼容指纹。
+
+### 5.4 Wire framing 与消息
+
+64-byte report 的冻结布局：
+
+```text
+byte 0      Report ID = 0x06
+byte 1      channel：0x02 RPC，0x01 debug
+byte 2      payload length：0..61
+byte 3..63  UTF-8 payload fragment，剩余补零
+```
+
+两个方向的结束规则不对称：
+
+- **Device → ChatGPT / Input Report**：逐 report 解码并拼接 UTF-8；完整 notification 或 RPC response 以 LF 结束。
+- **ChatGPT → Device / Output Report**：按最多 61 raw bytes 分片，不附加 LF；接收端在每个 fragment 后尝试解析完整 JSON。
+- UTF-8 多字节标量不能在 Input Report 边界被拆开；两侧都必须设置总长度和超时上限。
+
+已观测 notification：
+
+```json
+{"m":"v.oai.hid","p":{"k":"ACT12","act":1}}
+{"m":"v.oai.hid","p":{"k":"ACT12","act":0}}
+{"m":"v.oai.rad","p":{"a":0.75,"d":1}}
+```
+
+其中 `act=1/0` 表示按下/释放，`act=2` 表示 encoder detent。最小双向 RPC 面为：
+
+| method | 方向 | 用途 |
+| --- | --- | --- |
+| `sys.version` | ChatGPT → Device | 查询兼容/固件版本 |
+| `device.status` | ChatGPT → Device | 查询 profile、layer、电量与充电状态 |
+| `v.oai.rgbcfg` | ChatGPT → Device | 写入灯光配置 |
+| `v.oai.thstatus` | ChatGPT → Device | 写入六个 Agent 槽的状态灯模型 |
+| `v.oai.hid` | Device → ChatGPT | Agent、Command、encoder 等按键通知 |
+| `v.oai.rad` | Device → ChatGPT | Analog 角度和距离通知 |
+
+RPC request/response 通过 `id` 关联，每个 request 必须恰好响应一次。`Accepted` 只证明 report 被 transport 接收；没有 chat、composer 或 turn readback 时仍是 `AcceptedUnverified`。
+
+### 5.5 只读复现流程
+
+1. **冻结环境**：记录 ChatGPT Desktop 完整版本、平台、安装包来源和测试账户能力；复制待分析文件后计算 SHA-256。
+2. **静态定位**：只读搜索 `codex-micro-service`、`codex-micro-bridge`、Work Louder 依赖、`v.oai.*` method、设备身份和 layout key；不修改或重新打包应用。
+3. **枚举 HID**：记录 VID、PID、Usage Page、Usage、Report ID、Input/Output report 长度和设备路径；把物理 USB、Bluetooth 与虚拟设备结果分开保存。
+4. **先被动后主动**：先观察 ChatGPT 发出的 version/status/lighting Output Report；随后在隔离的非关键 chat 中一次只验证一个无破坏动作。
+5. **关联可见结果**：为每个 report 保存 sequence、时间、方向和脱敏摘要，并记录 ChatGPT UI/readback；不能用“写入成功”替代动作成功。
+6. **虚拟回环**：使用最小 vendor-defined descriptor 复现设备，只实现有界 framing、必要 RPC、held release 和 analog neutral；未知 method 返回明确 error。
+7. **交叉验证**：至少覆盖 Agent tap、Command tap、PTT down/up、encoder step/press、Analog center→direction→center、灯光与断连恢复。
+8. **生成兼容 manifest**：固定 build hashes、设备形状、消息 schema 和 golden vectors；任何关键字段变化都进入 `Incompatible`，不得猜测继续发送。
+
+### 5.6 已确认、推断与未知
+
+| 状态 | 结论 |
+| --- | --- |
+| 官方确认 | 实体设备支持 USB-C/Bluetooth；ChatGPT 首次检测后提供设置；Codex 使用 layer 1；macOS 需要 Input Monitoring |
+| 目标 build 已确认 | ChatGPT 的 Codex 通道选择 vendor-defined HID 形状，使用 64-byte 双向 report、私有 JSON notification/RPC 和 renderer bridge |
+| 虚拟回环已确认 | Windows VHF 设备使用相同 VID/PID/Usage/Report 后，26.707/26.715 可完成按键、旋钮、Analog、设置路由和灯光 RPC |
+| 高可信推断 | 零售实体设备的 Codex layer 1 使用相同 vendor HID 合同；仍应保存实体 descriptor 抓取作独立证据 |
+| 未确认 | Bluetooth 是 BLE HOGP 还是 Classic HID、无线接口是否与 USB descriptor 完全相同、未来 ChatGPT build 的兼容性 |
+| 不成立 | “设备枚举成功就等于 ChatGPT 已识别”“transport ACK 就等于业务成功”“私有 ABI 是官方 SDK” |
+
+### 5.7 安全、合规与发布边界
+
+- 逆向证据只用于互操作和兼容研究；日志不得保存 prompt、任务正文、凭据或完整用户数据。
+- 不修改 ChatGPT 包体、不注入 renderer、不绕过审批/权限，也不把 UIA 点击伪装成 Micro 原生动作。
+- VID `0x303A` 属于 Espressif 标识；本仓库没有证明第三方有权公开发行 `PID 0x8360`。虚拟设备身份只限隔离研究，正式分发前需要书面授权或官方兼容身份。
+- 未签名开发驱动不能要求用户关闭 Secure Boot、签名强制或导入来源不明的根证书；公开发行必须另行完成身份、签名、HLK/WHCP、安装与卸载 Gate。
+- `Accepted`、`OutcomeUnknown` 或 `Rejected` 后禁止自动改走第二通道；只有明确 `NotSent` 才允许预先定义的 fallback。
+- Codex build、任一关键散列、VID/PID、Usage、Report ID、report 长度、method schema 或 layout 形状改变时必须 fail closed。
+
+完整的逐 build 逆向笔记、状态推导和 descriptor 见 [`docs/codex-26.707.12708-vhf-status-input.zh-CN.md`](../../docs/codex-26.707.12708-vhf-status-input.zh-CN.md)；发行与身份决策见 [ADR-0002](../../docs/adr/0002-codex-micro-native-compatibility.zh-CN.md)。
+
+## 6. USB-C 与 Bluetooth 的区别
+
+| 项目 | USB-C | Bluetooth |
+| --- | --- | --- |
+| 初次接入 | 插入支持数据的 USB-C 线 | 使用键盘左下角触控区选择 Bluetooth 1/2/3 并配对 |
+| Codex 通道 | 已观测为 vendor-defined USB HID，Usage Page `0xFF00` | 由 OS 暴露给 ChatGPT；具体 BLE HOGP/Classic HID profile 未被公开或冻结 |
+| 稳定性排查 | 先检查线材是否支持数据、端口与供电 | 先检查所选频道、配对记录与电量 |
+| ChatGPT 设置 | 检测后相同 | 检测后相同 |
+| Codex layer | layer 1 | layer 1 |
+| 额外层 | layer 2–6 由 Work Louder Input 配置 | 同左 |
+
+Bluetooth 重新配对使用**左下角触控区**；背部按钮只控制电源，不用于开始配对。具体固件、复位与多层配置以 [Work Louder Creator Micro 2 设置指南](https://worklouder.cc/micro-setup)为准。
+
+## 7. 实体 Micro 与本仓库虚拟 Micro 的区别
+
+```mermaid
+flowchart TB
+    subgraph Physical["官方实体路径"]
+        PM["Codex Micro 实体键盘"] -->|USB vendor HID / Bluetooth| POS["OS HID/设备栈"]
+        POS --> PApp["ChatGPT Desktop"]
+    end
+
+    subgraph Virtual["本仓库实验虚拟路径"]
+        AC["Agent Controller / virtual-micro"] --> Client["Micro Broker Client"]
+        Client --> Broker["AgentController.MicroBroker"]
+        Broker --> VHF["CodexMicroVhfUm / VHF"]
+        VHF --> VHID["Windows 虚拟 HID child"]
+        VHID --> VApp["ChatGPT Desktop"]
+    end
+```
+
+| 项目 | 实体 Codex Micro | Agent Controller / `virtual-micro` |
+| --- | --- | --- |
+| 与电脑连接 | USB-C 或 Bluetooth | 本地 named pipe → Broker → Windows VHF 虚拟 HID |
+| 是否需要本仓库驱动 | 否 | Full Micro 模式需要实验性 `CodexMicroVhfUm` |
+| 是否需要 Agent Controller | 否 | 手柄映射路径需要；独立 `virtual-micro` 模拟器不依赖主程序 |
+| 官方支持状态 | ChatGPT Desktop 官方产品集成 | 非官方、私有兼容实验 |
+| 配置入口 | Settings > Codex Micro | Agent Controller 设置 + ChatGPT 的 Micro layout 门禁 |
+
+所以如果用户手上有实体 Codex Micro，正常接法就是“键盘 → USB-C/Bluetooth → 电脑 → ChatGPT Desktop”；不需要先接入 Agent Controller，也不需要安装本仓库的 VHF 驱动。
+
+## 8. 相关资料
+
+- [官方 Codex Micro 指南](https://learn.chatgpt.com/docs/features/codex-micro)
+- [架构与输入链路](architecture-and-input-flow.md)
+- [Codex Micro 指令参考](codex-micro-command-reference.md)
+- [Codex 26.707 逆向证据与 VHF 协议](../../docs/codex-26.707.12708-vhf-status-input.zh-CN.md)
+- [ADR-0002：原生 Micro 兼容决策](../../docs/adr/0002-codex-micro-native-compatibility.zh-CN.md)
+- [实体键盘模拟器安装教程](../../docs/CodexMicroSimulator-安装教程.zh-CN.md)
+- [Work Louder Creator Micro 2 设置指南](https://worklouder.cc/micro-setup)

--- a/public/docs/interface-design.md
+++ b/public/docs/interface-design.md
@@ -1,0 +1,245 @@
+# 界面与交互设计
+
+> Status: Current WPF information architecture and interaction contract
+>
+> Updated: 2026-07-19
+> Scope: 主窗口、侧边栏导航弹层、LB/RB/RT/Y 操作层、反馈与主题
+
+界面服务于两种不同场景：主窗口用于连接、学习、浏览和配置；Overlay 用于用户留在 Codex 中时的短时操作。Overlay 只显示当前按键层和必要反馈，不能发展成第二个完整 Agent 客户端。
+
+## 1. 设计原则
+
+1. **物理位置优先**：用方向、键帽和当前控制器 glyph 表达输入，不能把 Xbox 的 ABXY 字母硬编码给所有手柄。
+2. **上下文可见**：用户必须看见当前处于 Base、Agent、Command、Running 还是 Action 层。
+3. **危险动作可撤销或需确认**：Stop 使用 3 秒长按；清空输入使用二次确认；Approval/Decline 必须显示目标上下文。
+4. **反馈诚实**：区分已发送、已接受但未验证、已验证成功、被阻断和不兼容。
+5. **不遮挡 Codex 关键控件**：弹层优先位于上部或侧边；模型/Composer 原生菜单由 Codex 自己显示。
+6. **渐进式教学**：Learning 模式显示位置提示；Always 保留操作层；Off 只保留必要反馈。
+
+## 2. 主窗口信息架构
+
+```mermaid
+flowchart TD
+    Window["Agent Controller 主窗口"] --> Header["顶栏：品牌 / 一级导航 / 连接状态 / Bridge"]
+    Window --> Device["设备页"]
+    Window --> Config["配置页"]
+    Window --> Settings["设置页"]
+    Window --> Footer["底栏：最近状态 / 版本"]
+
+    Device --> Tutorial["动态手柄教程 + Live input"]
+    Device --> Quick["六个高频操作速查卡"]
+    Device --> Dial["右摇杆 / Micro encoder 状态"]
+    Device --> Sidebar["任务与项目目录"]
+    Device --> Events["最近事件"]
+
+    Config --> LeftStick["左摇杆目录行为"]
+    Config --> RightStick["右摇杆 Composer 行为"]
+    Config --> Shortcuts["Agent 快捷键与恢复建议值"]
+
+    Settings --> Behavior["前台门禁 / 震动 / Overlay 模式"]
+    Settings --> Tuning["死区 / 首次重复 / 重复间隔"]
+    Settings --> System["语言 / 开机启动 / 托盘 / 外部设置"]
+```
+
+### 2.1 窗口骨架
+
+| 区域 | 当前合同 |
+| --- | --- |
+| 窗口 | 默认 `1220 × 800`，最小 `1060 × 690`，居中启动 |
+| 顶栏 | 高 `66`；左侧品牌，中间“设备/配置/设置”，右侧连接状态与 Bridge 总开关 |
+| 内容区 | 外边距 `18`；三个页面同位切换，不重新创建窗口 |
+| 底栏 | 高 `38`；左侧事件/状态，右侧版本 |
+| 键盘导航 | `TabNavigation=Cycle`；可用键盘完成主要设置与列表操作 |
+
+### 2.2 设备页线框
+
+```text
+┌──────────────────────────────────────────────────────────────────────────┐
+│ 动态手柄教程 + 当前按键高亮                         [LIVE INPUT]         │
+│                                                                          │
+│ [主操作] [语音] [发送] [取消/撤回] [项目上下文] [唤醒 Codex]            │
+├──────────────────────────────────────────┬───────────────────────────────┤
+│                                          │ 右摇杆 / Micro encoder         │
+│ 教程与手柄示意                            │ 当前模式、方向、选中值          │
+│                                          ├───────────────────────────────┤
+│                                          │ 任务/项目目录                   │
+│                                          │ scope、项目过滤、列表、刷新      │
+│                                          ├───────────────────────────────┤
+│                                          │ 最近事件                        │
+└──────────────────────────────────────────┴───────────────────────────────┘
+```
+
+设备页左侧承载学习，右侧承载当前目标与任务浏览；六张速查卡只展示高频入口，不复制全部组合层指令。控制器未连接时保持教程可读，但 Live input 与连接状态必须明确降级。
+
+### 2.3 配置与设置的职责
+
+| 页面 | 负责 | 不负责 |
+| --- | --- | --- |
+| 配置 | 解释左右摇杆行为、展示/编辑 Agent 快捷键、恢复推荐值 | 运行时状态、设备诊断、通用系统偏好 |
+| 设置 | Bridge 之外的行为门禁、Overlay 模式、摇杆参数、语言、自启动与托盘 | 业务 Action 映射编辑器；当前版本尚未提供自定义 binding UI |
+
+“配置”回答“控制如何映射”，“设置”回答“应用如何运行”。未来新增自定义 Profile 时，应形成独立的 Binding/Profile 流程，不继续向两个页面堆字段。
+
+## 3. Overlay 家族
+
+Overlay 统一使用实体键帽、动作标题、可选副标题和可选确认进度。固定宽度 `804` 的现有面板出现在透明 Overlay 上部，为下方 Codex popup 保留空间。
+
+| 入口 | 形态 | 内容 | 退出 |
+| --- | --- | --- | --- |
+| LB hold | 2 × 3 Agent keypad | 槽位 1–6、任务标题、状态灯、当前选择 | 松开 LB 或 B |
+| RB hold | 2 × 3 Action menu | Fast、Approve、Decline、Fork、PTT、Dispatch | 松开 RB 或 L3 |
+| RT hold | 2 × 2 Action menu | Steer、Queue、Stop、Fork | RT 回落到 release threshold |
+| Y | 2 × 3 Action menu | New task、Forward、Toggle sidebar、Back、Clear、Project context | Y 或 B |
+| R3 / 右摇杆 | Codex 原生 Composer menu | Model、Effort、Speed/Power 等实际可用项 | B 上下文返回 |
+
+![四类操作层的设计参考](../../docs/ux/overlay-family-gpt-image-2.png)
+
+这张图用于说明同族布局与信息密度；最终文案、glyph、状态与可用性以运行时 ViewModel 和 XAML 为准。R3 区域是 Codex 自身界面，不应由 Agent Controller 伪造一套静态模型清单。
+
+### 3.1 LB Agent keypad
+
+LB 层使用 2 × 3 Micro 风格键盘，不使用圆盘、放射连线或中央手柄照片。
+
+```text
+┌ LB Agent ─────────────────────────────────────────────┐
+│ [↑  ●  Agent 1 title]   [→  ●  Agent 2 title]        │
+│ [↓  ●  Agent 3 title]   [←  ●  Agent 4 title]        │
+│ [View ● Agent 5 title]  [Menu ● Agent 6 title]       │
+└───────────────────────────────────────────────────────┘
+```
+
+![LB Agent 面板设计参考](../../docs/ux/lb-agent-panel-gpt-image-2.png)
+
+状态灯语义：
+
+| 灯状态 | 含义 | 展示规则 |
+| --- | --- | --- |
+| 灭 | 未绑定或无可信状态 | 不显示成 Idle |
+| 暖白 | Idle | 任务可用但未运行 |
+| 蓝 | Thinking/Running | 只在有运行证据时显示 |
+| 绿 | Complete unread | 已完成且用户尚未查看 |
+| 琥珀 | Requires input | 仅在有审批/提问证据时显示；不能由“仍在运行”猜测 |
+| 红 | Error | 有明确错误事件 |
+
+颜色必须与标题/状态文本共同表达，不得只靠颜色。当前 Micro `thstatus` 只有 slot 状态时，若缺少可靠 slot→thread proof，不得覆盖命名任务的状态。
+
+### 3.2 RB / RT / Y 动作菜单
+
+每一行只包含：物理键帽、动作标题、必要时一行副标题、必要时一条进度。选择状态使用统一强调色；危险语义通过动作名称、说明与确认进度表达，不把整张面板染成红色。
+
+| 状态 | 视觉反馈 |
+| --- | --- |
+| 默认 | 中性键帽和标题 |
+| 当前按键/焦点 | 单一强调背景或描边 |
+| 不可用 | 降低对比度并保留原因；不能静默消失导致布局跳动 |
+| 等待二次确认 | 副标题显示“再次按下确认”与剩余窗口 |
+| 长按确认 | 连续进度条；提前松开立即归零 |
+| 执行中 | 短暂活动状态；不提前显示成功 |
+| 成功/失败 | 由 Overlay feedback、底栏或事件日志给出结果 |
+
+### 3.3 侧边栏导航弹层
+
+侧边栏弹层把“选择 scope/项目”和“选择任务”分成相邻卡片：左摇杆上下移动，左右进入/退出层级，A 打开任务，L3 循环根 scope。目录选择与任务打开必须分离，避免移动焦点时意外切换 Codex 任务。
+
+![侧边栏导航弹层结构参考](../../docs/assets/ux-sidebar-action-menu-concept.png)
+
+弹层不能覆盖 Codex popup。若无法保持 TopMost 或安全位置，反馈回落到主窗口/底栏，不在 Codex 关键区域强行叠加。
+
+## 4. 反馈层级
+
+```mermaid
+flowchart TD
+    Event["输入或 Action 结果"] --> Need{"用户现在需要处理吗?"}
+    Need -->|是：确认/阻断/失败| Overlay["Overlay：短、明确、可行动"]
+    Need -->|否：持续状态| Footer["底栏：连接、Bridge、执行状态"]
+    Event --> Log["最近事件：时间、动作、结果、原因"]
+    Overlay --> Log
+    Footer --> Log
+```
+
+| 反馈面 | 适用内容 | 文案要求 |
+| --- | --- | --- |
+| 顶栏状态 | 控制器连接、Bridge 开关 | 持续、简短，不随每次动作闪烁 |
+| Overlay | 当前层、确认倒计时、阻断、重要失败 | 一个动作、一个结果、一个下一步 |
+| 底栏 | 最近一次非阻塞状态 | 不遮挡、不抢焦点 |
+| 最近事件 | 调试与回溯 | 时间、Action/输入、outcome、executor/error；不记录 prompt 正文 |
+
+推荐结果词汇与 `ActionOutcome` 对齐：成功、未发送、已接受但未验证、不支持、不兼容、已阻止、失败。不要把“已发送按键”写成“操作成功”。
+
+## 5. 主题与组件规范
+
+应用主题由 `app/Themes/` 中的 token 和控件样式组成：
+
+- `Tokens.Colors.xaml`：sand/sage 基础色、文字、边框与状态色；
+- `Tokens.Typography.xaml`：UI/mono 字体与字号层级；
+- `Tokens.Metrics.xaml`：间距、圆角与尺寸；
+- `Tokens.Elevation.xaml`：主窗口卡片与 Overlay 层级；
+- `Tokens.Motion.xaml`：教学、选择和状态灯节奏；
+- `Controls/*.xaml`：按钮、分段导航、卡片、输入、列表、状态与 Overlay。
+
+新增视图必须优先复用 token 与共享样式，禁止在页面内重新创造一套颜色、圆角和阴影。状态色只承载状态；普通分类和装饰不用彩虹式分色。
+
+## 6. 可访问性与输入兼容
+
+- 所有主要设置保留键盘访问、可见焦点和可读标签。
+- L3/R3 文案必须同时解释为 LS/RS 垂直按压，不能用“向下拨摇杆”的图示。
+- 手柄 glyph 来自当前 `ControllerProfile`；字母与物理位置同时展示时，以物理位置为主。
+- 颜色状态同时提供文本、形状或图标；不能只靠红/绿区分。
+- 动画应短暂并尊重系统减少动画偏好；状态灯脉冲不能成为唯一信息源。
+- Overlay 不抢占 Codex 文本输入焦点；关闭层后恢复原目标或明确报告无法恢复。
+- 中英文文本长度不同，标题允许截断但关键动作和确认文案不能被裁掉。
+
+## 7. 界面状态与空状态
+
+| 条件 | 主窗口 | Overlay/手柄行为 |
+| --- | --- | --- |
+| 未连接控制器 | 显示等待状态与静态教程 | 不显示操作层 |
+| 控制器已连接但未回中 | 显示设备，提示等待 neutral | 不消费残留按键边沿 |
+| Bridge off | 顶栏开关关闭，持续说明“手柄不会控制 Codex” | 禁止所有 Codex 动作；只做 release/neutral 清理 |
+| Codex 不在前台且前台门禁开启 | 显示目标未就绪 | Menu 可在 Bridge on 时唤醒；其他动作 Blocked |
+| Micro 不可用 | 显示 Limited/NotSent，而非 Full Micro | 仅走预先定义的语义回退 |
+| layout 不可验证 | 标注不兼容/自定义映射未知 | 对应 `ACT*` fail closed |
+| 无任务 | 目录显示空状态和新建入口 | LB 槽位显示未绑定，不伪造任务 |
+| 动作结果未知 | 保留“已接受但未验证” | 不自动双发；允许用户手工核对 |
+
+## 8. 验收清单
+
+### 主窗口
+
+- 三个一级页面职责清楚，连接状态与 Bridge 在任何页面都可见。
+- `1060 × 690` 下无关键文字、按钮或列表被裁切。
+- 键盘可访问顶栏、列表、表单、保存与外部设置按钮。
+- 设备页在连接、断开、空任务、长标题和中英文下均保持稳定布局。
+
+### Overlay
+
+- LB 六槽顺序固定为上/右、下/左、View/Menu；与 `AgentRadialSlotLayout.Bindings` 一致。
+- RB/Y 为 2 × 3，RT 为真实 2 × 2；未使用行折叠，不留空白槽。
+- Learning/Always/Off 三种模式只改变说明密度，不改变输入语义。
+- Stop、Clear、Approve/Decline 的确认和取消路径可见、可中断。
+- Overlay 不抢 composer 焦点，不遮挡 Codex popup，不把 transport ACK 误呈现为成功。
+
+### 状态与国际化
+
+- Unknown、Idle、Running、Requires input、Complete unread、Error 可区分且有非颜色提示。
+- 所有用户可见字符串来自本地化 catalog；动态 Agent 名称与控制器 glyph 可安全插值。
+- 最近事件不包含 prompt、任务正文或凭据。
+
+## 9. 代码索引
+
+| 界面 | 代码入口 |
+| --- | --- |
+| 主窗口骨架 | `app/MainWindow.xaml` |
+| 设备页 | `app/Views/DevicePageView.xaml` |
+| 配置页 | `app/Views/ConfigPageView.xaml` |
+| 设置页 | `app/Views/SettingsPageView.xaml` |
+| 动态教程 | `app/Views/ControllerTutorialView.xaml` |
+| LB Agent keypad | `app/Views/AgentKeypadView.xaml` |
+| RB/RT/Y action menu | `app/Views/ActionMenuView.xaml` |
+| Overlay 容器与切换 | `app/Views/RadialMenuView.xaml`、`RadialMenuOverlayWindow.xaml` |
+| 侧边栏导航弹层 | `app/Views/SidebarNavigationMenuView.xaml` |
+| 主题与组件 | `app/Themes/` |
+| Overlay ViewModel | `app/ViewModels/RadialMenuViewModel.cs`、`RadialMenuSlotViewModel.cs` |
+| 页面 ViewModel | `app/ViewModels/DevicePageViewModel.cs`、`ConfigPageViewModel.cs`、`SettingsPageViewModel.cs` |
+
+交互或界面修改后，至少同步更新对应 XAML、ViewModel、本地化 catalog、设计测试、[手柄操作列表](controller-operations.md)和[系统指令映射](system-design-and-command-map.md)。

--- a/public/docs/system-design-and-command-map.md
+++ b/public/docs/system-design-and-command-map.md
@@ -1,0 +1,330 @@
+# 系统设计、UML 与指令映射
+
+> Status: Current implementation map + target boundaries
+>
+> Updated: 2026-07-19
+> Scope: Agent Controller WPF 客户端、Application/Domain 骨架、Micro Broker 与 Codex 适配器
+
+本文回答四个问题：系统由哪些部分组成、一次操作如何流转、物理输入最终映射成什么指令、各类结果如何判定。用户操作以[手柄操作列表](controller-operations.md)为准；Micro wire 细节以[Codex Micro 指令参考](codex-micro-command-reference.md)为准；历史 v0.7 差异只在[旧版指令清单](controller-command-reference-v0.7.md)中维护。
+
+实体 Codex Micro 通过 USB-C 或 Bluetooth 直接连接电脑，不经过本仓库的 Broker/VHF 路径；部署和时序见[Codex Micro 实体键盘接入与 UML](codex-micro-physical-connection.md)。
+
+## 1. 文档边界与术语
+
+| 资料 | 回答的问题 | 是否作为当前合同 |
+| --- | --- | --- |
+| 本文 | 组件、核心类型、路由、Action ID、执行通道 | 是 |
+| [手柄操作列表](controller-operations.md) | 用户按什么、会发生什么 | 是 |
+| [界面与交互设计](interface-design.md) | 主窗口、弹层、状态、反馈如何呈现 | 是 |
+| [架构与输入链路](architecture-and-input-flow.md) | Micro 设备平面、Broker、驱动与输入时序 | 是 |
+| [Codex Micro 指令参考](codex-micro-command-reference.md) | HID/RPC/report 的观测合同 | 兼容合同；必须指纹门禁 |
+| [v0.7 指令清单](controller-command-reference-v0.7.md) | 旧实现、旧规范与差异 | 否；仅历史基线 |
+
+统一术语：
+
+- **物理输入**：手柄按钮、扳机或摇杆原始状态。
+- **逻辑输入**：按物理位置归一化后的 `LogicalInput`，例如 `FaceSouth`，不依赖 Xbox/Nintendo 的字母布局。
+- **意图**：一次已去抖、已识别上下文的操作，例如 `SendPrompt` 或 `NavigateSidebarHorizontal`。
+- **Action**：Agent 无关、可记录结果的业务命令，例如 `composer.submit`。
+- **Micro 投影**：把允许的意图变为 `AG*`、`ACT*`、`ENC*` 或 Analog report。
+- **执行证据**：transport、状态或 UI 回读；`Accepted` 只代表 transport 接收，不代表业务成功。
+
+## 2. 系统上下文 UML
+
+```mermaid
+flowchart LR
+    User["用户"] --> Pad["XInput 兼容手柄"]
+    User --> Desktop["Agent Controller 主窗口"]
+
+    subgraph AC["Agent Controller"]
+        Pad --> Input["XInputService\n状态缓冲 / 手势 / Profile"]
+        Input --> Coord["ControllerInteractionCoordinator\nHold / Layer / Intent"]
+        Coord --> Local["本地导航与 Overlay"]
+        Coord --> Dispatch["ActionDispatcher"]
+        Dispatch --> Router["ActionRouter"]
+        Router --> Exec["Codex Action Executors"]
+        Coord --> Micro["MicroInputService"]
+        Desktop --> Settings["Settings / Localization / ViewModels"]
+        Desktop --> Local
+    end
+
+    Exec --> Agent["Codex adapter\nApp/UI/shortcut/deeplink"]
+    Micro --> Broker["当前用户 Micro Broker"]
+    Broker --> Driver["CodexMicroVhfUm\nUMDF2 / VHF"]
+    Driver --> Codex["Codex Desktop\nservice + renderer bridge"]
+    Agent --> Codex
+    Codex --> Readback["可见状态 / UI 回读 / RPC"]
+    Readback --> Exec
+    Readback --> Micro
+```
+
+这张图是**当前渐进迁移状态**：`Domain` 与 `Application` 已承载稳定 Action 合同和路由，但部分输入协调、Codex 自动化和 WPF composition 仍在 `app/`。目标依赖方向见[目标项目结构](../../docs/architecture/target-project-structure.zh-CN.md)，不能把目标目录误写成已经完成的现状。
+
+## 3. 核心类 UML
+
+```mermaid
+classDiagram
+    class Gesture {
+        +GestureKind Kind
+        +ControlId[] Controls
+        +TimeSpan HoldThreshold
+        +int StepDelta
+    }
+    class BindingRule {
+        +string Id
+        +Gesture Gesture
+        +InputContext Context
+        +ActionId ActionId
+        +int Priority
+    }
+    class ActionRequest {
+        +Guid RequestId
+        +ActionId ActionId
+        +ActionSource Source
+        +InputContext Context
+        +string IdempotencyKey
+        +ActionSafetyLevel SafetyLevel
+    }
+    class ActionDispatcher {
+        +ExecuteAsync()
+    }
+    class ActionRouter {
+        +ExecuteAsync(ActionRequest)
+    }
+    class IActionExecutor {
+        <<interface>>
+        +ProbeAsync(ActionRequest)
+        +ExecuteAsync(ActionRequest)
+    }
+    class ActionResult {
+        +ActionOutcome Outcome
+        +string ExecutorId
+        +ActionEvidence[] Evidence
+        +string ErrorCode
+    }
+    class ActionEvidence {
+        +ActionEvidenceKind Kind
+        +string Source
+        +string Code
+        +double Confidence
+    }
+    class StateObservation~T~ {
+        +T Value
+        +string Source
+        +long Epoch
+        +long Sequence
+        +double Confidence
+    }
+
+    BindingRule --> Gesture
+    BindingRule --> ActionRequest : selects ActionId
+    ActionDispatcher --> ActionRequest : creates
+    ActionDispatcher --> ActionRouter
+    ActionRouter o-- IActionExecutor : probes all
+    IActionExecutor --> ActionResult : returns
+    ActionResult o-- ActionEvidence
+    ActionEvidence ..> StateObservation : may derive from
+```
+
+关键约束：
+
+1. `ActionDispatcher` 生成 request ID 与幂等键；调用方不能用一个模糊的 bool 代替结果。
+2. `ActionRouter` 先探测全部 executor，再按 capability priority 选择；没有可用实现时返回 `Blocked`、`Incompatible` 或 `Unsupported`。
+3. `ActionResult` 固定保留 outcome、executor、证据与错误码；transport 与业务结果不能混为一谈。
+4. `StateObservation<T>` 用 source、epoch、sequence、时间与 confidence 标识状态来源，避免把推断状态冒充权威状态。
+
+## 4. 输入与层状态机
+
+```mermaid
+stateDiagram-v2
+    [*] --> Disabled: Bridge off
+    Disabled --> Base: Bridge on + neutral
+    Base --> Disabled: Bridge off / disconnect cleanup
+
+    Base --> AgentCandidate: LB down
+    AgentCandidate --> Base: LB release < 180 ms / previous task
+    AgentCandidate --> AgentLayer: hold >= 180 ms
+    AgentLayer --> Base: release or cancel
+
+    Base --> CommandCandidate: RB down
+    CommandCandidate --> Base: RB release < 180 ms / next task
+    CommandCandidate --> CommandLayer: hold >= 180 ms
+    CommandLayer --> Base: release or cancel
+
+    Base --> TurnLayer: RT >= 0.55
+    TurnLayer --> Base: RT <= 0.35
+    Base --> ActionPanel: Y
+    ActionPanel --> Base: Y or B
+
+    Base --> MicroMenuSession: R3 short / ENC tap
+    MicroMenuSession --> MicroMenuSession: right stick or R3
+    MicroMenuSession --> Base: B / contextual AG00
+```
+
+Bridge 关闭是入口总门控。关闭后可以继续设备发现、被动显示与 release/neutral 清理，但不能用 Menu、摇杆、扳机或按钮控制 Codex。
+
+## 5. 一次 Action 的执行时序
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor User as 用户
+    participant Input as 输入协调器
+    participant Dispatcher as ActionDispatcher
+    participant Router as ActionRouter
+    participant Executors as Executors
+    participant Codex as Codex
+    participant Readback as 结果观测
+
+    User->>Input: 按下已映射控制
+    Input->>Input: Bridge / foreground / context / hold 检查
+    Input->>Dispatcher: ActionId + source + safety + context
+    Dispatcher->>Router: ActionRequest（唯一 request/idempotency）
+    Router->>Executors: ProbeAsync（全部候选）
+    Executors-->>Router: capability + priority + reason
+    Router->>Executors: ExecuteAsync（最优可用候选）
+    Executors->>Codex: Micro / semantic API / verified UI / shortcut
+    Codex-->>Readback: transport、状态或界面变化
+    Readback-->>Executors: evidence
+    Executors-->>Router: ActionResult
+    Router-->>Input: outcome + evidence + error
+    Input-->>User: overlay / footer / event log
+```
+
+## 6. 物理输入到操作的总映射
+
+### 6.1 Base 层
+
+| 物理输入 | 逻辑/意图 | 业务 Action 或本地操作 | 首选执行通道 | 安全说明 |
+| --- | --- | --- | --- | --- |
+| Menu | `Menu` | 唤醒/置前 Codex | foreground adapter | Bridge off 时禁止 |
+| 左摇杆上/下 | `LeftStick` | 同级目录移动 | 本地 sidebar directory | 只移动焦点，不立即打开 |
+| 左摇杆左/右 | `LeftStick` | 退出/进入项目目录 | 本地 sidebar directory | 进入项目不等于打开任务 |
+| L3 | `LeftStickPress` | 循环根 scope | 本地 sidebar state | 置顶任务 → 置顶项目 → 项目 → 未归项目 |
+| A | `FaceSouth` / `OpenSelectedSidebarTask` | `thread.open` | deeplink/open-thread executor | 只打开已确认任务 ID |
+| X | `FaceWest` / `SendPrompt` | `composer.submit` | 验证 layout 后 `ACT12`，否则语义 adapter | 非空并验证清空后才可报成功；禁用 Enter 回退 |
+| B 短按 | `FaceEast` | 上下文返回/取消/撤回 | Micro 菜单会话、局部 cancel 或 `navigation.undo` | 普通 Base 不得盲发 `AG00` |
+| B 长按 3 秒 | `FaceEast` / hold | `turn.stop` | 当前为已验证 composer/UI adapter；目标为语义 turn interrupt | 高风险；提前松开取消 |
+| Y | `FaceNorth` / `OpenActionPanel` | 打开 Y 动作面板 | 本地 UI | 冻结 Base 路由 |
+| 十字键上/下 | `DPadUp/Down` | `conversation.previous-user-message` / `conversation.next-user-message` | verified navigation adapter | 长按分别触发 top/bottom |
+| 右摇杆上/左 | axis step | `EncoderStep(+1)` | `ENC_CW act=2` | 不承担进入/确认 |
+| 右摇杆下/右 | axis step | `EncoderStep(-1)` | `ENC_CC act=2` | 不承担进入/确认 |
+| R3 短按 | `RightStickPress` | `EncoderPress` | `ENC` down/up | 建立 Micro 菜单会话 |
+| R3 长按 500 ms | hold | 打开 Agent Controller 设置 | 本地窗口 | 抑制同一次 `ENC` 短按 |
+| LT 按住/松开 | `LeftTrigger` | PTT start/stop | layout 验证后 `ACT10` down/up | release 不得丢失 |
+| LB/RB 短按 | shoulder tap | 上一个/下一个可用任务 | 本地任务导航 | 180 ms 内释放才是 tap |
+
+### 6.2 上下文层
+
+| 层 | 输入 | 操作 | Action / wire |
+| --- | --- | --- | --- |
+| LB Agent | 十字键上/右/下/左 | Agent 槽 1–4 | `AG00..AG03` tap |
+| LB Agent | View / Menu | Agent 槽 5–6 | `AG04..AG05` tap |
+| LB Agent | B | 取消本层 | 本地 cancel |
+| RB Command | Y | Fast | layout 验证后的 `ACT06` / `composer.toggleFastMode` |
+| RB Command | A | Approve | `approval.accept`；默认 Micro `ACT07` |
+| RB Command | B | Decline | `approval.decline`；默认 Micro `ACT08` |
+| RB Command | X | Fork | `thread.fork`；默认 Micro `ACT09` |
+| RB Command | View 按住 | PTT | `ACT10` down/up |
+| RB Command | Menu | Dispatch | 当前 composer 的 Send / Steer / Queue |
+| RT Running | X | Steer | `turn.steer` |
+| RT Running | Y | Queue | `turn.queue` |
+| RT Running | B 长按 3 秒 | Stop | `turn.stop` |
+| RT Running | A | Fork | `thread.fork` |
+| Y Action | 十字键上 | 新建任务 | `thread.create` |
+| Y Action | 十字键右/左 | 历史前进/后退 | `navigation.forward` / `navigation.back` |
+| Y Action | 十字键下 | 侧边栏开关 | `sidebar.toggle` |
+| Y Action | A 两次 | 清空 composer | `composer.clear`，二次确认 |
+| Y Action | X | 项目上下文 | 本地 sidebar project context |
+
+## 7. Action ID 与执行器映射
+
+| Action ID | 风险级别 | 当前主要执行器/通道 | 成功判据 |
+| --- | --- | --- | --- |
+| `thread.open` | Routine | `CodexOpenThreadActionExecutor` / deeplink | 目标 thread 被确认打开 |
+| `thread.create` | Routine | `CodexCreateThreadActionExecutor` / 可见命令，必要时官方快捷键 | 新任务界面可见 |
+| `thread.fork` | Routine（当前） | `CodexForkThreadActionExecutor` / 验证 Micro → shortcut → UI command | 当前通常为 `AcceptedUnverified`；有 fork/branch readback 后才可升级为成功 |
+| `composer.submit` | Routine | `CodexComposerActionExecutor` / 验证 `ACT12` 或 composer adapter | 当前 transport/快捷键路径为 `AcceptedUnverified`；有权威 turn 证据后才可升级为成功 |
+| `composer.clear` | ConfirmationRequired | `CodexComposerActionExecutor` | composer 为空且目标编辑器未变 |
+| `turn.stop` | HighRisk | `CodexComposerActionExecutor`，目标为语义 stop | 当前 turn 终止；不能只凭点击成功 |
+| `turn.steer` | Routine（当前） | 当前为可见 composer 命令；目标为语义 turn adapter | 当前通常为 `AcceptedUnverified`；需 follow-up 进入当前 turn 的证据 |
+| `turn.queue` | Routine（当前） | 当前为可见 composer 命令；目标为语义 turn adapter | 当前通常为 `AcceptedUnverified`；需 follow-up 进入下一 turn 队列的证据 |
+| `approval.accept` | HighRisk | `CodexUiCommandActionExecutor` / 验证 `ACT07` 或可见审批命令 | 对应 approval 消失或状态改变 |
+| `approval.decline` | Routine（当前） | `CodexUiCommandActionExecutor` / 验证 `ACT08` 或可见拒绝命令 | 当前通常为 `AcceptedUnverified`；对应 approval 状态变化后才可升级为成功 |
+| `conversation.*` | Routine | `CodexConversationActionExecutor` | 已验证滚动/消息位置变化 |
+| `navigation.back` / `forward` | Routine | shell/verified navigation adapter | 历史位置变化；不能误作 composer 光标移动 |
+| `navigation.undo` | Routine | `CodexNavigationUndoActionExecutor` | 本地导航栈与目标任务恢复 |
+| `sidebar.toggle` | Routine | shell/verified sidebar adapter | 侧边栏可见性变化 |
+
+`ActionSafetyLevel` 是请求合同；UI 的长按、二次确认和上下文检查是其交互实现。新增高风险 Action 时，两者必须同时更新。
+
+### 7.1 当前需要收敛的合同差异
+
+| 项目 | 当前代码 | 产品/交互合同 | 收敛方向 |
+| --- | --- | --- | --- |
+| Decline 风险级别 | `Routine`，无需二次确认 | Approval/Decline 都要求先验证审批上下文 | 明确是否升为 `HighRisk`；若保持 Routine，也必须补目标与结果 readback |
+| Fork 风险级别 | `Routine`，Micro/快捷键/UI 任一路径都多为未验证接受 | 组合层把 Fork 作为直接动作 | 保持直接动作时补 fork readback，不能把 transport 接受写成成功 |
+| Steer / Queue | `Routine`，当前按可见按钮名调用 | 只应在已验证 RunningTurn 上下文开放 | 迁入语义 turn adapter，并让 capability probe 拒绝错误上下文 |
+| Stop | `HighRisk` + 3 秒长按，但 UIA 点击后仍是未验证 | 需要权威 turn interrupt 与终止证据 | App Server 垂直切片完成后替换当前主路径 |
+
+在这些差异解决前，本文表格中的“当前”列优先描述代码事实；[手柄操作列表](controller-operations.md)中的“首选通道”描述产品目标。
+
+## 8. Micro 指令映射
+
+| 语义 | wire key | `act` / 时序 | 发送前门禁 |
+| --- | --- | --- | --- |
+| 上一项 | `ENC_CW` | `2`，每档一条 | 设备与 build 兼容；步数 `1..64` |
+| 下一项 | `ENC_CC` | `2`，每档一条 | 同上 |
+| 打开/进入/确认 | `ENC` | `1 → 0` | R3 短按；长按不得泄漏 tap |
+| Agent 1–6 | `AG00..AG05` | `1 → 0` | 槽位 `0..5`；菜单返回的 `AG00` 仅限会话内 |
+| Fast | `ACT06` | `1 → 0` | 当前 layout 必须解析为 `composer.toggleFastMode` |
+| Approve | `ACT07` | `1 → 0` | layout + approval context |
+| Decline | `ACT08` | `1 → 0` | layout + approval context |
+| Fork | `ACT09` | `1 → 0` | layout + fork context |
+| PTT | `ACT10` | 按住 `1`，松开 `0` | layout 必须解析为 `dictation.pushToTalk`；异常时补 neutral |
+| Submit | `ACT12` | `1 → 0` | layout 必须解析为 `composer.submit` |
+| Analog pulse | `v.oai.rad` | neutral → direction → neutral | angle/distance 有限；最终 neutral 必达 |
+
+`ACT*` 是可重映射物理槽，不是永久业务常量。`CodexMicroLayoutResolver` 只读解析当前 Codex layout；无法证明映射时必须 `NotSent`，不得按默认键帽猜测。
+
+## 9. 执行结果与 fallback 决策
+
+```mermaid
+flowchart TD
+    Start["尝试首选通道"] --> Result{"结果"}
+    Result -->|NotSent| Fallback{"存在预先定义且已验证的 fallback?"}
+    Fallback -->|是| Second["执行第二通道并独立验证"]
+    Fallback -->|否| Unsupported["报告 Unsupported / NotSent"]
+    Result -->|Accepted| Verify["等待业务 readback"]
+    Result -->|OutcomeUnknown| Unknown["报告 AcceptedUnverified；禁止自动重发"]
+    Result -->|Rejected| Reject["报告错误；禁止双发"]
+    Verify -->|已验证| Success["Succeeded + evidence"]
+    Verify -->|未验证/超时| Unknown
+```
+
+| 结果 | 用户可理解含义 | 后续动作 |
+| --- | --- | --- |
+| `Succeeded` | 动作已由结果证据确认 | 更新状态与日志 |
+| `NotSent` | 首选通道确认没有发送 | 只允许预先定义的 fallback |
+| `AcceptedUnverified` | 可能已执行，但尚无业务证据 | 禁止非幂等重试，提示用户核对 |
+| `Unsupported` | 当前适配器没有该能力 | 显示可恢复建议 |
+| `Incompatible` | build、layout 或设备合同不匹配 | fail closed，要求修复兼容性 |
+| `Blocked` | Bridge、前台、权限或上下文不满足 | 显示具体阻断原因 |
+| `Failed` | 已知执行失败 | 保留 executor、错误码与证据 |
+
+## 10. 代码索引与维护规则
+
+| 主题 | 代码入口 |
+| --- | --- |
+| Composition | `app/Composition/AppComposition.cs` |
+| 物理位置归一化 | `app/Controllers/LogicalInput.cs` |
+| 输入意图 | `app/Controllers/ControllerInteractionIntent.cs` |
+| LB/RB/RT/Y 映射 | `app/Controllers/RadialInputMap.cs` |
+| Action 合同 | `src/AgentController.Application/Actions/*ActionContract.cs` |
+| Action 请求/结果/证据 | `src/AgentController.Domain/Actions/` |
+| 路由与执行器选择 | `src/AgentController.Application/Actions/ActionRouter.cs` |
+| Micro 投影 | `app/Services/Micro/MicroInputService.cs` |
+| Micro layout 门禁 | `app/Services/Micro/CodexMicroLayoutResolver.cs` |
+| Broker | `src/AgentController.MicroBroker/` |
+
+每次更改绑定时，至少同步检查：`RadialInputMap`、教程文案、Overlay 槽位、本文总映射、`controller-operations.md` 与对应测试。每次更改 Micro 指令时，还必须更新 golden vector/协议测试和 `codex-micro-command-reference.md`。


### PR DESCRIPTION
## What

- Reorganizes the design documentation index.
- Adds system UML, operation lists, action IDs, and command mappings.
- Adds interface and overlay interaction design.
- Documents the Codex Micro physical connection path, observed vendor-defined USB HID framing, RPC surface, evidence levels, and repeatable reverse-engineering workflow.

## Why

This separates official setup guidance from the private ABI observed in a pinned ChatGPT Desktop build, while recording confidence levels, open questions, and fail-closed compatibility boundaries.

## Impact

Documentation only. No runtime behavior changes.

## Checks

- Local Markdown links resolve.
- Each document has one H1 and balanced code fences.
- Mermaid labels avoid angle-bracket stereotypes that render as escaped HTML.
- `git diff --cached --check` passed before commit.

Code tests were not run because this change only updates documentation.
