### PR TITLE
release(micro): DeepSeek Harness Keypad v0.2.6

### DIFF
--- a/micro-bridge/DeepSeekHarness/README.md
+++ b/micro-bridge/DeepSeekHarness/README.md
@@ -52,6 +52,11 @@ WSL mode uses bounded UTF-8 JSON over loopback HTTP. Native Windows mode can
 use one JSON line on `\\.\pipe\deepseek-harness-micro-v1`. Protocol version is
 `1` and source is `codex-micro`.
 
+Normal DSH tabs can report state, but they never receive physical-key focus,
+session, action, or dictation frames. If no confirmed dedicated surface is
+connected, the bridge returns `opening` so the Windows keypad host can open an
+Edge-first app-mode window without depending on WSL executable interop.
+
 General actions:
 
 - `activate`
@@ -73,6 +78,7 @@ and the keypad; the keypad connects directly to its configured voice provider.
 
 ```powershell
 pnpm run verify
+pnpm run test:e2e
 ```
 
 This runs strict TypeScript checking, browser/pipe/loopback-HTTP tests, and

--- a/micro-bridge/DeepSeekHarness/README.zh.md
+++ b/micro-bridge/DeepSeekHarness/README.zh.md
@@ -47,6 +47,10 @@ WSL 模式使用带大小限制的回环 HTTP UTF-8 JSON；原生 Windows 模式
 `\\.\pipe\deepseek-harness-micro-v1` 上使用单行 JSON。协议版本为 `1`，来源为
 `codex-micro`。
 
+普通 DSH 标签页可以上报状态，但不会接收小键盘的聚焦、会话、动作或听写帧。没有
+已确认的专用窗口时，Bridge 返回 `opening`，由 Windows 小键盘主程序优先使用 Edge
+打开 app-mode 窗口，不依赖 WSL 的 Windows 可执行文件 interop。
+
 通用动作：
 
 - `activate`
@@ -68,6 +72,7 @@ WSL 模式使用带大小限制的回环 HTTP UTF-8 JSON；原生 Windows 模式
 
 ```powershell
 pnpm run verify
+pnpm run test:e2e
 ```
 
 该命令执行严格 TypeScript 检查、浏览器/命名管道/回环 HTTP 测试，并构建 Host 与

--- a/micro-bridge/DeepSeekHarness/package.json
+++ b/micro-bridge/DeepSeekHarness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentcontroller/dsh-micro-bridge-deepseek-harness",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "External DeepSeek Harness adapter for AgentController Micro native actions and keypad dictation",
   "license": "MIT",
   "type": "module",
@@ -37,6 +37,7 @@
     "build": "node scripts/clean.mjs && tsdown",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
+    "test:e2e": "vitest run tests/node-half.client.spec.ts -t \"e2e:\"",
     "verify": "pnpm run typecheck && pnpm run test && pnpm run build",
     "prepare": "pnpm run build"
   },

--- a/micro-bridge/DeepSeekHarness/src/index.ts
+++ b/micro-bridge/DeepSeekHarness/src/index.ts
@@ -165,9 +165,8 @@ export const internals: {
   platform: NodeJS.Platform
   runNativeCommand: NativeCommandRunner
   now: () => number
+  isWsl: () => boolean
   windowsAppBrowser: () => string | undefined
-  wslWindowsAppBrowser: () => string | undefined
-  wslWindowsUrlHandler: () => string | undefined
   launchWindowsAppBrowser: (executable: string, url: string) => Promise<number>
   openWebUi: (url: string, signal: AbortSignal) => Promise<number | undefined>
 } = {
@@ -175,6 +174,8 @@ export const internals: {
   platform: process.platform,
   runNativeCommand,
   now: Date.now,
+  isWsl: () => process.env.WSL_INTEROP !== undefined
+    || process.env.WSL_DISTRO_NAME !== undefined,
   windowsAppBrowser() {
     const roots = [process.env['ProgramFiles(x86)'], process.env.ProgramFiles]
       .filter((value): value is string => value !== undefined && value.trim() !== '')
@@ -182,26 +183,6 @@ export const internals: {
       join(root, 'Microsoft', 'Edge', 'Application', 'msedge.exe'),
       join(root, 'Google', 'Chrome', 'Application', 'chrome.exe'),
     ])
-    return candidates.find(candidate => existsSync(candidate))
-  },
-  wslWindowsAppBrowser() {
-    if (process.env.WSL_INTEROP === undefined &&
-        process.env.WSL_DISTRO_NAME === undefined) return undefined
-    const candidates = [
-      '/mnt/c/Program Files (x86)/Microsoft/Edge/Application/msedge.exe',
-      '/mnt/c/Program Files/Microsoft/Edge/Application/msedge.exe',
-      '/mnt/c/Program Files/Google/Chrome/Application/chrome.exe',
-      '/mnt/c/Program Files (x86)/Google/Chrome/Application/chrome.exe',
-    ]
-    return candidates.find(candidate => existsSync(candidate))
-  },
-  wslWindowsUrlHandler() {
-    if (process.env.WSL_INTEROP === undefined &&
-        process.env.WSL_DISTRO_NAME === undefined) return undefined
-    const candidates = [
-      '/mnt/c/Windows/System32/rundll32.exe',
-      '/mnt/c/WINDOWS/System32/rundll32.exe',
-    ]
     return candidates.find(candidate => existsSync(candidate))
   },
   launchWindowsAppBrowser(executable, url) {
@@ -242,29 +223,10 @@ export const internals: {
         await internals.runNativeCommand('open', [url], signal)
         return undefined
       case 'linux':
-        {
-          const windowsAppBrowser = internals.wslWindowsAppBrowser()
-          if (windowsAppBrowser !== undefined) {
-            // The Harness host lives in WSL, but its UI remains a native
-            // Windows app window.  Launch app mode directly so repeated
-            // Micro activation can be matched and raised by HWND instead of
-            // spraying ordinary browser tabs through the URL handler.
-            await internals.launchWindowsAppBrowser(windowsAppBrowser, url)
-            // The pid returned by a WSL interop spawn belongs to the Linux
-            // relay, not the native Windows browser.  Let Micro locate the
-            // guarded Harness window by title/process instead.
-            return undefined
-          }
-          const windowsUrlHandler = internals.wslWindowsUrlHandler()
-          if (windowsUrlHandler !== undefined) {
-            await internals.runNativeCommand(
-              windowsUrlHandler,
-              ['url.dll,FileProtocolHandler', url],
-              signal,
-            )
-            return undefined
-          }
-        }
+        // A WSL host cannot assume that Windows executable interop is
+        // registered. The Windows Micro process owns the physical key and
+        // launches the Edge app-mode surface after receiving `opening`.
+        if (internals.isWsl()) return undefined
         await internals.runNativeCommand('xdg-open', [url], signal)
         return undefined
       default:
@@ -382,10 +344,12 @@ function resolveSessionStatus(
   browserStatus: MicroSessionStatus | undefined,
 ): MicroSessionStatus {
   // Pending interaction is the DeepSeek sidebar's primary state even while
-  // the underlying turn remains active. The host list is authoritative for
-  // the coarse running bit; browser-only completion/error states apply once
-  // the host confirms that work is no longer running.
+  // the underlying turn remains active. A dedicated browser surface can see a
+  // turn start before the host session list refreshes, so its running state
+  // must light the Agent key immediately. Browser-only completion/error states
+  // still apply only after the host confirms that work is no longer running.
   if (browserStatus === 'waiting') return 'waiting'
+  if (browserStatus === 'running') return 'running'
   if (row.running) return 'running'
   if (browserStatus === 'completed' || browserStatus === 'error') {
     return browserStatus
@@ -408,7 +372,7 @@ class MicroBridge {
   private readonly reportWaiters = new Map<string, (report?: MicroBrowserReport) => void>()
   private readonly nativeTasks = new Set<Promise<unknown>>()
   private readonly abort = new AbortController()
-  private readonly pendingFrames: MicroBrowserFrame[] = []
+  private readonly pendingDedicatedFrames: MicroBrowserFrame[] = []
   private readonly pendingVoiceRequests: MicroKeypadVoiceRequest[] = []
   private readonly voiceRequestWaiters = new Set<
     (request?: MicroKeypadVoiceRequest) => void
@@ -473,11 +437,7 @@ class MicroBridge {
         this.dedicatedBrowsers.delete(browserId)
       }
     })
-    if (this.pendingFrames.length !== 0) {
-      for (const frame of this.pendingFrames.splice(0)) {
-        res.write(sseFrame(frame))
-      }
-    }
+    this.flushPendingDedicatedFrames(browserId)
   }
 
   /** Accept browser presence and exact frame acknowledgements. */
@@ -500,6 +460,7 @@ class MicroBridge {
       if (report.surface === 'dedicated') {
         this.dedicatedBrowsers.add(report.browserId)
         this.dedicatedOpenPending = false
+        this.flushPendingDedicatedFrames(report.browserId)
       } else {
         this.dedicatedBrowsers.delete(report.browserId)
       }
@@ -853,7 +814,7 @@ class MicroBridge {
       case 'activate': {
         const requestId = randomUUID()
         const frame = { version: MICRO_PROTOCOL_VERSION, type: 'activate', requestId } as const
-        const delivery = await this.deliver(frame, FOCUS_ACK_TIMEOUT_MS)
+        const delivery = await this.deliver(frame, FOCUS_ACK_TIMEOUT_MS, 'dedicated')
         if (!delivery.delivered) {
           const processId = await this.scheduleOpenOnce()
           return response(
@@ -880,11 +841,11 @@ class MicroBridge {
         // Windows it can remain true while another top-level application is
         // in front, so let Codex Micro perform and verify the native HWND
         // activation instead of returning a false "foreground" success.
-        if (!delivery.report.visible && delivery.report.surface !== 'dedicated') {
+        if (delivery.report.surface !== 'dedicated') {
           const processId = await this.scheduleOpenOnce()
           return response(
             true,
-            'DeepSeek Harness was in a background tab; a dedicated window is opening.',
+            'DeepSeek Harness lost its dedicated surface; a dedicated window is opening.',
             'opening',
             undefined,
             processId,
@@ -908,9 +869,9 @@ class MicroBridge {
           requestId: randomUUID(),
           sessionId: request.sessionId,
         }
-        const delivery = await this.deliver(frame, FOCUS_ACK_TIMEOUT_MS)
+        const delivery = await this.deliver(frame, FOCUS_ACK_TIMEOUT_MS, 'dedicated')
         if (!delivery.delivered) {
-          this.pendingFrames.push(frame)
+          this.pendingDedicatedFrames.push(frame)
           const processId = await this.scheduleOpenOnce()
           return response(
             true,
@@ -935,11 +896,11 @@ class MicroBridge {
         if (!delivery.report.success) {
           return response(false, delivery.report.message ?? 'DeepSeek Harness rejected the session.')
         }
-        if (!delivery.report.visible && delivery.report.surface !== 'dedicated') {
+        if (delivery.report.surface !== 'dedicated') {
           const processId = await this.scheduleOpenOnce()
           return response(
             true,
-            'The selected DeepSeek Harness session opened in a background tab; a dedicated window is opening.',
+            'The selected DeepSeek Harness session lost its dedicated surface; a dedicated window is opening.',
             'opening',
             undefined,
             processId,
@@ -961,9 +922,9 @@ class MicroBridge {
           actionId: request.actionId,
           ...(request.sessionId === undefined ? {} : { sessionId: request.sessionId }),
         }
-        const delivery = await this.deliver(frame, ACTION_ACK_TIMEOUT_MS)
+        const delivery = await this.deliver(frame, ACTION_ACK_TIMEOUT_MS, 'dedicated')
         if (!delivery.delivered) {
-          this.pendingFrames.push(frame)
+          this.pendingDedicatedFrames.push(frame)
           const processId = await this.scheduleOpenOnce()
           return response(
             true,
@@ -1042,9 +1003,9 @@ class MicroBridge {
             ? {}
             : { dictationPhase: request.dictationPhase }),
         }
-        const delivery = await this.deliver(frame, ACTION_ACK_TIMEOUT_MS)
+        const delivery = await this.deliver(frame, ACTION_ACK_TIMEOUT_MS, 'dedicated')
         if (!delivery.delivered) {
-          this.pendingFrames.push(frame)
+          this.pendingDedicatedFrames.push(frame)
           const processId = await this.scheduleOpenOnce()
           return response(
             false,
@@ -1091,9 +1052,11 @@ class MicroBridge {
           id: row.sessionId,
           displayTitle: displayTitle(row),
           status,
-          // Preserve the v1 coarse bit for older keypads. `waiting` can be
-          // primary while the underlying turn is still running.
-          running: row.running,
+          // Preserve the v1 coarse bit for older keypads, but derive it from
+          // the merged status so a browser-observed start lights the Agent key
+          // while the host list is still catching up. `waiting` is also an
+          // active turn for clients that do not understand detailed statuses.
+          running: status === 'running' || status === 'waiting',
           updatedAt: row.updatedAt,
         }
       })
@@ -1122,8 +1085,9 @@ class MicroBridge {
   private async deliver(
     frame: MicroBrowserFrame & { requestId: string },
     timeoutMs: number,
+    requiredSurface?: MicroBrowserReport['surface'],
   ): Promise<{ delivered: boolean; report?: MicroBrowserReport }> {
-    const target = this.preferredBrowser()
+    const target = this.preferredBrowser(requiredSurface)
     if (target === undefined) return { delivered: false }
     const report = this.waitForReport(frame.requestId, timeoutMs)
     target.response.write(sseFrame(frame))
@@ -1152,7 +1116,7 @@ class MicroBridge {
     })
   }
 
-  private preferredBrowser(): {
+  private preferredBrowser(requiredSurface?: MicroBrowserReport['surface']): {
     response: ServerResponse
     state?: MicroBrowserReport & { reportedAt: number }
   } | undefined {
@@ -1165,12 +1129,15 @@ class MicroBridge {
     for (const [browserId, response] of this.browserConnections) {
       if (response.destroyed || response.writableEnded) {
         this.browserConnections.delete(browserId)
+        this.browserReports.delete(browserId)
+        this.dedicatedBrowsers.delete(browserId)
         continue
       }
       const state = this.browserReports.get(browserId)
+      if (requiredSurface !== undefined && state?.surface !== requiredSurface) continue
       const score = (state?.focused === true ? 4 : 0)
         + (state?.visible === true ? 2 : 0)
-        + (state?.surface === 'dedicated' ? 1 : 0)
+        + (state?.surface === 'dedicated' ? 8 : 0)
       const candidate = {
         response,
         score,
@@ -1187,6 +1154,21 @@ class MicroBridge {
     return {
       response: preferred.response,
       ...(preferred.state === undefined ? {} : { state: preferred.state }),
+    }
+  }
+
+  /**
+   * Physical-key frames must never be consumed by a normal DSH browser tab.
+   * Wait until the SSE connection has explicitly reported itself as the
+   * dedicated app surface, regardless of whether events or the report arrives
+   * first during startup.
+   */
+  private flushPendingDedicatedFrames(browserId: string): void {
+    if (!this.dedicatedBrowsers.has(browserId)) return
+    const response = this.browserConnections.get(browserId)
+    if (response === undefined || response.destroyed || response.writableEnded) return
+    for (const frame of this.pendingDedicatedFrames.splice(0)) {
+      response.write(sseFrame(frame))
     }
   }
 

--- a/micro-bridge/DeepSeekHarness/tests/node-half.client.spec.ts
+++ b/micro-bridge/DeepSeekHarness/tests/node-half.client.spec.ts
@@ -119,36 +119,113 @@ async function mount(rows: Array<Record<string, unknown>> = []): Promise<{
 
 const baseRequest = { version: Bridge.MICRO_PROTOCOL_VERSION, source: 'codex-micro' } as const
 
+async function readSseFrame(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  timeoutMs = 1_500,
+): Promise<Bridge.MicroBrowserFrame> {
+  const decoder = new TextDecoder()
+  const reading = (async (): Promise<Bridge.MicroBrowserFrame> => {
+    let buffered = ''
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) throw new Error('SSE stream ended before a frame arrived')
+      buffered += decoder.decode(value, { stream: true })
+      let boundary = buffered.indexOf('\n\n')
+      while (boundary !== -1) {
+        const block = buffered.slice(0, boundary)
+        buffered = buffered.slice(boundary + 2)
+        const data = block
+          .split(/\r?\n/u)
+          .filter(line => line.startsWith('data:'))
+          .map(line => line.slice(5).trimStart())
+          .join('\n')
+        if (data !== '') return JSON.parse(data) as Bridge.MicroBrowserFrame
+        boundary = buffered.indexOf('\n\n')
+      }
+    }
+  })()
+  let timeout: ReturnType<typeof setTimeout> | undefined
+  try {
+    return await Promise.race([
+      reading,
+      new Promise<never>((_resolve, reject) => {
+        timeout = setTimeout(() => {
+          reject(new Error(`Timed out waiting ${String(timeoutMs)}ms for an SSE frame`))
+        }, timeoutMs)
+      }),
+    ])
+  } finally {
+    if (timeout !== undefined) clearTimeout(timeout)
+  }
+}
+
+interface ConnectedTestBrowser {
+  abort: AbortController
+  reader: ReadableStreamDefaultReader<Uint8Array>
+}
+
+async function connectTestBrowser(
+  origin: string,
+  browserId: string,
+  surface: Bridge.MicroBrowserReport['surface'],
+  focused: boolean,
+): Promise<ConnectedTestBrowser> {
+  const abort = new AbortController()
+  const stream = await fetch(
+    `${origin}${Bridge.MICRO_EVENTS_ENDPOINT}?browserId=${encodeURIComponent(browserId)}`,
+    { signal: abort.signal },
+  )
+  if (stream.body === null) throw new Error(`missing ${browserId} SSE body`)
+  const reader = stream.body.getReader()
+  const reported = await fetch(`${origin}${Bridge.MICRO_REPORT_ENDPOINT}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      version: Bridge.MICRO_PROTOCOL_VERSION,
+      browserId,
+      currentSessionId: null,
+      visible: true,
+      focused,
+      surface,
+      navigationDepth: 0,
+    }),
+  })
+  if (reported.status !== 204) {
+    abort.abort()
+    await reader.cancel().catch(() => {})
+    throw new Error(`${browserId} report failed with ${String(reported.status)}`)
+  }
+  return { abort, reader }
+}
+
+async function disconnectTestBrowser(browser: ConnectedTestBrowser): Promise<void> {
+  browser.abort.abort()
+  await browser.reader.cancel().catch(() => {})
+}
+
 describe('external DeepSeek Harness host bundle', () => {
-  it('opens a dedicated Windows app surface from WSL without a command shell', async () => {
+  it('defers a WSL app surface to the Windows keypad host', async () => {
     const runNativeCommand = vi.fn(async () => {})
     const launchWindowsAppBrowser = vi.fn(async () => 27_001)
     Bridge.internals.platform = 'linux'
-    Bridge.internals.wslWindowsAppBrowser = () =>
-      '/mnt/c/Program Files (x86)/Microsoft/Edge/Application/msedge.exe'
-    Bridge.internals.wslWindowsUrlHandler = () =>
-      '/mnt/c/Windows/System32/rundll32.exe'
+    Bridge.internals.isWsl = () => true
     Bridge.internals.runNativeCommand = runNativeCommand
     Bridge.internals.launchWindowsAppBrowser = launchWindowsAppBrowser
 
-    await Bridge.internals.openWebUi(
+    const processId = await Bridge.internals.openWebUi(
       'http://127.0.0.1:3080/?codexMicroSurface=1',
       new AbortController().signal,
     )
 
-    expect(launchWindowsAppBrowser).toHaveBeenCalledWith(
-      '/mnt/c/Program Files (x86)/Microsoft/Edge/Application/msedge.exe',
-      'http://127.0.0.1:3080/?codexMicroSurface=1',
-    )
+    expect(processId).toBeUndefined()
+    expect(launchWindowsAppBrowser).not.toHaveBeenCalled()
     expect(runNativeCommand).not.toHaveBeenCalled()
   })
 
-  it('falls back to the Windows URL handler from WSL when app mode is unavailable', async () => {
+  it('uses the native Linux URL handler outside WSL', async () => {
     const runNativeCommand = vi.fn(async () => {})
     Bridge.internals.platform = 'linux'
-    Bridge.internals.wslWindowsAppBrowser = () => undefined
-    Bridge.internals.wslWindowsUrlHandler = () =>
-      '/mnt/c/Windows/System32/rundll32.exe'
+    Bridge.internals.isWsl = () => false
     Bridge.internals.runNativeCommand = runNativeCommand
 
     await Bridge.internals.openWebUi(
@@ -157,11 +234,8 @@ describe('external DeepSeek Harness host bundle', () => {
     )
 
     expect(runNativeCommand).toHaveBeenCalledWith(
-      '/mnt/c/Windows/System32/rundll32.exe',
-      [
-        'url.dll,FileProtocolHandler',
-        'http://127.0.0.1:3080/?codexMicroSurface=1',
-      ],
+      'xdg-open',
+      ['http://127.0.0.1:3080/?codexMicroSurface=1'],
       expect.any(AbortSignal),
     )
   })
@@ -193,6 +267,283 @@ describe('external DeepSeek Harness host bundle', () => {
       success: true,
       state: { sessions: [{ id: 'wsl-session' }] },
     })
+  })
+
+  it('e2e: a focused normal Chrome tab cannot intercept the DeepSeek key', async () => {
+    const {
+      eventHandler,
+      reportHandler,
+      controlHandler,
+      openWebUi,
+    } = await mount()
+    httpServer = createHttpServer((req, res) => {
+      if (req.url?.startsWith(Bridge.MICRO_EVENTS_ENDPOINT) === true) {
+        void eventHandler(req, res)
+      } else if (req.url === Bridge.MICRO_REPORT_ENDPOINT) {
+        void reportHandler(req, res)
+      } else if (req.url === Bridge.MICRO_CONTROL_ENDPOINT) {
+        void controlHandler(req, res)
+      } else {
+        res.writeHead(404)
+        res.end()
+      }
+    })
+    await new Promise<void>((resolve, reject) => {
+      httpServer?.once('error', reject)
+      httpServer?.listen(0, '127.0.0.1', () => { resolve() })
+    })
+    const address = httpServer.address()
+    if (address === null || typeof address === 'string') throw new Error('missing test port')
+    const origin = `http://127.0.0.1:${String(address.port)}`
+    const tabAbort = new AbortController()
+    let tabStream: Response | undefined
+    try {
+      tabStream = await fetch(
+        `${origin}${Bridge.MICRO_EVENTS_ENDPOINT}?browserId=focused-chrome-tab`,
+        { signal: tabAbort.signal },
+      )
+      const reported = await fetch(`${origin}${Bridge.MICRO_REPORT_ENDPOINT}`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          version: Bridge.MICRO_PROTOCOL_VERSION,
+          browserId: 'focused-chrome-tab',
+          currentSessionId: null,
+          visible: true,
+          focused: true,
+          surface: 'tab',
+          navigationDepth: 0,
+        }),
+      })
+      expect(reported.status).toBe(204)
+
+      const activated = await fetch(`${origin}${Bridge.MICRO_CONTROL_ENDPOINT}`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ ...baseRequest, action: 'activate' }),
+      })
+
+      expect(activated.status).toBe(200)
+      await expect(activated.json()).resolves.toMatchObject({
+        success: true,
+        status: 'opening',
+        windowProcessId: 41_944,
+      })
+      expect(openWebUi).toHaveBeenCalledOnce()
+      expect(openWebUi.mock.calls[0]?.[0]).toContain('codexMicroSurface=1')
+    } finally {
+      tabAbort.abort()
+      await tabStream?.body?.cancel().catch(() => {})
+    }
+  })
+
+  it('e2e: the DeepSeek key beats a focused tab and targets the dedicated surface', async () => {
+    const {
+      eventHandler,
+      reportHandler,
+      controlHandler,
+      openWebUi,
+    } = await mount([
+      { sessionId: 'agent-light-session', updatedAt: 50, running: false, blank: false },
+    ])
+    httpServer = createHttpServer((req, res) => {
+      if (req.url?.startsWith(Bridge.MICRO_EVENTS_ENDPOINT) === true) {
+        void eventHandler(req, res)
+      } else if (req.url === Bridge.MICRO_REPORT_ENDPOINT) {
+        void reportHandler(req, res)
+      } else if (req.url === Bridge.MICRO_CONTROL_ENDPOINT) {
+        void controlHandler(req, res)
+      } else {
+        res.writeHead(404)
+        res.end()
+      }
+    })
+    await new Promise<void>((resolve, reject) => {
+      httpServer?.once('error', reject)
+      httpServer?.listen(0, '127.0.0.1', () => { resolve() })
+    })
+    const address = httpServer.address()
+    if (address === null || typeof address === 'string') throw new Error('missing test port')
+    const origin = `http://127.0.0.1:${String(address.port)}`
+    const tabAbort = new AbortController()
+    const dedicatedAbort = new AbortController()
+    let tabStream: Response | undefined
+    let dedicatedReader: ReadableStreamDefaultReader<Uint8Array> | undefined
+    try {
+      tabStream = await fetch(
+        `${origin}${Bridge.MICRO_EVENTS_ENDPOINT}?browserId=focused-chrome-tab`,
+        { signal: tabAbort.signal },
+      )
+      const tabReported = await fetch(`${origin}${Bridge.MICRO_REPORT_ENDPOINT}`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          version: Bridge.MICRO_PROTOCOL_VERSION,
+          browserId: 'focused-chrome-tab',
+          currentSessionId: 'agent-light-session',
+          visible: true,
+          focused: true,
+          surface: 'tab',
+          navigationDepth: 0,
+          sessionStates: [{ id: 'agent-light-session', status: 'idle' }],
+        }),
+      })
+      expect(tabReported.status).toBe(204)
+
+      const dedicatedStream = await fetch(
+        `${origin}${Bridge.MICRO_EVENTS_ENDPOINT}?browserId=deepseek-app`,
+        { signal: dedicatedAbort.signal },
+      )
+      if (dedicatedStream.body === null) throw new Error('missing dedicated SSE body')
+      dedicatedReader = dedicatedStream.body.getReader()
+      const dedicatedReported = await fetch(`${origin}${Bridge.MICRO_REPORT_ENDPOINT}`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          version: Bridge.MICRO_PROTOCOL_VERSION,
+          browserId: 'deepseek-app',
+          currentSessionId: 'agent-light-session',
+          visible: true,
+          focused: false,
+          surface: 'dedicated',
+          navigationDepth: 0,
+          sessionStates: [{ id: 'agent-light-session', status: 'running' }],
+        }),
+      })
+      expect(dedicatedReported.status).toBe(204)
+
+      const stateRead = await fetch(`${origin}${Bridge.MICRO_CONTROL_ENDPOINT}`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ ...baseRequest, action: 'state/read' }),
+      })
+      await expect(stateRead.json()).resolves.toMatchObject({
+        success: true,
+        state: {
+          currentSessionId: 'agent-light-session',
+          sessions: [{ id: 'agent-light-session', status: 'running', running: true }],
+        },
+      })
+
+      const activation = fetch(`${origin}${Bridge.MICRO_CONTROL_ENDPOINT}`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ ...baseRequest, action: 'activate' }),
+      })
+      const frame = await readSseFrame(dedicatedReader)
+      expect(frame).toMatchObject({
+        version: Bridge.MICRO_PROTOCOL_VERSION,
+        type: 'activate',
+        requestId: expect.any(String),
+      })
+      if (!('requestId' in frame)) throw new Error('activation frame is missing requestId')
+      const acknowledged = await fetch(`${origin}${Bridge.MICRO_REPORT_ENDPOINT}`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          version: Bridge.MICRO_PROTOCOL_VERSION,
+          browserId: 'deepseek-app',
+          currentSessionId: 'agent-light-session',
+          visible: true,
+          focused: true,
+          surface: 'dedicated',
+          navigationDepth: 0,
+          sessionStates: [{ id: 'agent-light-session', status: 'running' }],
+          requestId: frame.requestId,
+          success: true,
+          message: 'Dedicated DeepSeek surface focused.',
+        }),
+      })
+      expect(acknowledged.status).toBe(204)
+      await expect((await activation).json()).resolves.toMatchObject({
+        success: true,
+        status: 'background',
+      })
+      expect(openWebUi).not.toHaveBeenCalled()
+    } finally {
+      tabAbort.abort()
+      dedicatedAbort.abort()
+      await Promise.all([
+        tabStream?.body?.cancel().catch(() => {}),
+        dedicatedReader?.cancel().catch(() => {}),
+      ])
+    }
+  })
+
+  it('e2e: a reconnecting tab cannot steal an action queued for the dedicated surface', async () => {
+    const {
+      eventHandler,
+      reportHandler,
+      controlHandler,
+      openWebUi,
+    } = await mount()
+    httpServer = createHttpServer((req, res) => {
+      if (req.url?.startsWith(Bridge.MICRO_EVENTS_ENDPOINT) === true) {
+        void eventHandler(req, res)
+      } else if (req.url === Bridge.MICRO_REPORT_ENDPOINT) {
+        void reportHandler(req, res)
+      } else if (req.url === Bridge.MICRO_CONTROL_ENDPOINT) {
+        void controlHandler(req, res)
+      } else {
+        res.writeHead(404)
+        res.end()
+      }
+    })
+    await new Promise<void>((resolve, reject) => {
+      httpServer?.once('error', reject)
+      httpServer?.listen(0, '127.0.0.1', () => { resolve() })
+    })
+    const address = httpServer.address()
+    if (address === null || typeof address === 'string') throw new Error('missing test port')
+    const origin = `http://127.0.0.1:${String(address.port)}`
+    const browsers: ConnectedTestBrowser[] = []
+    try {
+      browsers.push(await connectTestBrowser(
+        origin,
+        'initial-chrome-tab',
+        'tab',
+        true,
+      ))
+      const activation = await fetch(`${origin}${Bridge.MICRO_CONTROL_ENDPOINT}`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          ...baseRequest,
+          action: 'session/activate',
+          sessionId: 'queued-session',
+        }),
+      })
+      await expect(activation.json()).resolves.toMatchObject({
+        success: true,
+        status: 'opening',
+      })
+      expect(openWebUi).toHaveBeenCalledOnce()
+
+      // This connection reproduces the startup race that used to drain every
+      // pending physical-key frame before its surface report was known.
+      browsers.push(await connectTestBrowser(
+        origin,
+        'late-chrome-tab',
+        'tab',
+        false,
+      ))
+      const dedicated = await connectTestBrowser(
+        origin,
+        'deepseek-app',
+        'dedicated',
+        false,
+      )
+      browsers.push(dedicated)
+
+      await expect(readSseFrame(dedicated.reader)).resolves.toMatchObject({
+        version: Bridge.MICRO_PROTOCOL_VERSION,
+        type: 'session/activate',
+        requestId: expect.any(String),
+        sessionId: 'queued-session',
+      })
+    } finally {
+      await Promise.all(browsers.map(disconnectTestBrowser))
+    }
   })
 
   it('opens at most one dedicated web surface while startup is pending', async () => {

--- a/public/docs/README.md
+++ b/public/docs/README.md
@@ -15,6 +15,7 @@
 
 ## 历史、证据与验收
 
+- [Deepseek Harness Keypad v0.2.6 正式版说明](release-deepseek-harness-keypad-v0.2.6.md)
 - [Deepseek Harness Keypad v0.2.5 正式版说明](release-deepseek-harness-keypad-v0.2.5.md)
 - [Deepseek Harness Keypad v0.2.4 正式版说明](release-deepseek-harness-keypad-v0.2.4.md)
 - [v0.7 手柄指令清单](controller-command-reference-v0.7.md)：仅用于追踪旧实现与规范差异，不作为最新合同。

--- a/public/docs/release-deepseek-harness-keypad-v0.2.6.md
+++ b/public/docs/release-deepseek-harness-keypad-v0.2.6.md
@@ -1,0 +1,32 @@
+# Deepseek Harness Keypad v0.2.6（简体中文）
+
+这是 DeepSeek 专用窗口路由的可靠性修复版，并完整保留 v0.2.5 的 Agent 灯状态同步与本地语音修复。按 DeepSeek 键时，普通 Chrome 或 Edge 标签页不再抢占激活；Windows 主程序会优先使用 Edge 打开带专用标记的 app-mode 窗口。
+
+## 修复内容
+
+- 激活、Agent 会话、动作和听写帧只发送给已确认的专用 DeepSeek surface。
+- 启动过程中排队的帧只有在专用窗口完成 SSE 握手后才会投递，重连的普通标签页无法截走。
+- 专用窗口改由 Windows 小键盘主程序启动，Edge 优先、Chrome 仅作兼容回退，不再依赖可能失效的 WSL Windows-executable interop。
+- HWND 激活拒绝标题带 `Google Chrome` 或 `Microsoft Edge` 浏览器外壳的普通窗口。
+- 专用窗口报告任务已运行时，Agent 灯状态立即同步为 `running`，并同时修正旧版兼容字段，不再等待可能滞后的 host session list。
+- 新增三条 loopback HTTP/SSE E2E，覆盖普通标签抢激活、聚焦标签与专用窗口竞争、Agent 运行灯同步，以及重连标签抢排队动作。
+- 保留 Agent 键蓝/绿/橙/红状态同步、当前任务完成锁存，以及 Qwen3-ASR 单实例和侧车启动修复。
+
+## 下载选择
+
+- `Deepseek-Harness-Keypad-Full-v0.2.6-oneclick.exe`：推荐，内置 Windows .NET 运行时与官方 DSH WSL 载荷。
+- `Deepseek-Harness-Keypad-Full-v0.2.6-oneclick-no-dotnet.exe`：内置相同 DSH 载荷，需要另装 .NET 10 Desktop Runtime x64。
+- `Deepseek-Harness-Keypad-v0.2.6-win-x64.zip`：便携轻量包。
+- `Deepseek-Harness-Keypad-Bridge-v0.2.6.zip`：只给已有 DSH 使用的独立 Bridge。
+
+每个正式发布资产均附带独立 SHA-256 文件。
+
+---
+
+# Deepseek Harness Keypad v0.2.6 (English)
+
+This patch fixes dedicated-window routing while retaining the Agent-light and local-voice fixes from v0.2.5. A focused normal Chrome or Edge tab can no longer intercept the DeepSeek key. The Windows keypad host opens an Edge-first app-mode surface and delivers physical-key frames only after that dedicated surface is confirmed.
+
+The dedicated surface's `running` report now drives both the detailed Agent-light state and the legacy compatibility bit immediately, even while the host session list is stale. Three loopback HTTP/SSE E2E cases cover tab interception, focused-tab versus dedicated-surface routing, Agent running-light synchronization, and reconnect races for queued actions. Native HWND activation also rejects normal browser-chrome titles.
+
+Use `Deepseek-Harness-Keypad-Full-v0.2.6-oneclick.exe` for the recommended self-contained installer, or the `oneclick-no-dotnet` build when .NET 10 Desktop Runtime x64 is already installed. Portable keypad and standalone Bridge ZIPs are also included. Every asset has an adjacent SHA-256 file.

--- a/scripts/build-deepseek-full-payload.ps1
+++ b/scripts/build-deepseek-full-payload.ps1
@@ -1,6 +1,6 @@
 [CmdletBinding()]
 param(
-    [string]$Version = "0.2.5",
+    [string]$Version = "0.2.6",
     [string]$DistributionSource = "Ubuntu-24.04",
     [string]$BuildDistributionName = "CodexMicro-DeepSeek-Build-v025",
     [string]$VerifyDistributionName = "CodexMicro-DeepSeek-Verify-v025",

--- a/scripts/package-deepseek-oneclick.ps1
+++ b/scripts/package-deepseek-oneclick.ps1
@@ -1,6 +1,6 @@
 [CmdletBinding()]
 param(
-    [string]$Version = "0.2.5",
+    [string]$Version = "0.2.6",
     [string]$Runtime = "win-x64",
     [string]$BundledWslPayload,
     [double]$MaximumPackageMiB = 1024,

--- a/scripts/package-micro.ps1
+++ b/scripts/package-micro.ps1
@@ -1,6 +1,6 @@
 [CmdletBinding()]
 param(
-    [string]$Version = "0.2.5",
+    [string]$Version = "0.2.6",
     [string]$Runtime = "win-x64",
     [double]$MaximumPackageMiB = 15,
     [ValidateSet("standard", "deepseek", "deepseek-full")]

--- a/scripts/prepare-deepseek-full-rootfs.sh
+++ b/scripts/prepare-deepseek-full-rootfs.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 # one-click payload. This script must only run inside that throw-away distro.
 
 managed_user="${CODEX_MICRO_DSH_USER:-codexmicro}"
-release_version="${CODEX_MICRO_RELEASE_VERSION:-0.2.5}"
+release_version="${CODEX_MICRO_RELEASE_VERSION:-0.2.6}"
 runtime_root="/home/$managed_user/.local/share/codex-micro/deepseek"
 marker_root="/etc/codex-micro"
 

--- a/virtual-micro/DEEPSEEK-WINDOWS-SETUP.zh-CN.md
+++ b/virtual-micro/DEEPSEEK-WINDOWS-SETUP.zh-CN.md
@@ -156,13 +156,13 @@ Codex Micro 的协议适配参考上游
 
 ## Full oneclick 包
 
-`Deepseek-Harness-Keypad-Full-v0.2.5-oneclick.exe` 使用与在线配置相同的 8 步状态机，
+`Deepseek-Harness-Keypad-Full-v0.2.6-oneclick.exe` 使用与在线配置相同的 8 步状态机，
 但从安装目录的 `payload/deepseek-runtime.wsl` 导入干净载荷，不再下载 Linux 用户态、
 Node、pnpm 或 Harness。载荷预装的是 DeepSeek 官方 npm 包 `@deepseek-ai/dsh`，版本
 和 Node / pnpm 一起记录在 Bridge 的 `scripts/runtime-versions.env`；Bridge 没有修改
 DSH 源码，后续替换官方版本只需更新该清单并重建。
 
-另有 `Deepseek-Harness-Keypad-Full-v0.2.5-oneclick-no-dotnet.exe`，DSH 载荷完全相同，
+另有 `Deepseek-Harness-Keypad-Full-v0.2.6-oneclick-no-dotnet.exe`，DSH 载荷完全相同，
 但不包含 Windows .NET 运行时。它和便携 ZIP 需要安装
 [Microsoft .NET 10 Desktop Runtime x64 官方安装程序](https://dotnet.microsoft.com/en-us/download/dotnet/thank-you/runtime-desktop-10.0.10-windows-x64-installer)；
 推荐 oneclick 已自带 .NET。两种 oneclick 都按当前用户安装到 Windows API 返回的

--- a/virtual-micro/HARNESS-ADAPTERS.md
+++ b/virtual-micro/HARNESS-ADAPTERS.md
@@ -75,15 +75,17 @@ example, port 3098 exposes `deepseek-harness-micro-v1-3098`; register that
 value as an external manifest's `pipeName` when the instance should appear as
 a separate Micro target.
 
-If a browser page is already connected, activation is delivered to the best
-focused/visible client through the bridge's same-origin SSE channel. The
-browser reports its current session, visibility, focus result, and whether it
-is the dedicated Micro surface to `POST /integrations/codex-micro/report`.
-When the only client is a hidden tab (or no client exists), the bridge opens
-one Edge/Chrome app-mode window tagged `codexMicroSurface=1`. A pending/open
-guard prevents repeated button presses from multiplying tabs while it starts.
-The WPF host then uses Win32 foreground activation on that dedicated browser
-window without synthesizing keyboard or pointer input.
+The browser reports its current session, visibility, focus result, and whether
+it is the dedicated Micro surface to
+`POST /integrations/codex-micro/report`. Normal browser tabs may contribute
+read-only state, but physical-key activation, session, action, and dictation
+frames are delivered only to a confirmed dedicated surface. When none exists,
+the bridge returns `opening` and the Windows WPF host opens one app-mode window,
+preferring Edge and using Chrome only as a compatibility fallback. The window
+is tagged `codexMicroSurface=1`; a pending/open guard prevents repeated button
+presses from multiplying windows while it starts. The WPF host then uses Win32
+foreground activation only on a dedicated browser window, without synthesizing
+keyboard or pointer input.
 
 The ACT12 key displays the seven activation phases directly on the key. During
 program-managed first use, the same key and setup window display the eight

--- a/virtual-micro/README.md
+++ b/virtual-micro/README.md
@@ -169,19 +169,19 @@ Use Windows 10/11 x64 and .NET SDK 10. From the repository root:
 
 ```powershell
 dotnet build .\virtual-micro\src\CodexMicro.DesktopHost\CodexMicro.DesktopHost.csproj -c Release
-.\scripts\package-micro.ps1 -Version 0.2.5
+.\scripts\package-micro.ps1 -Version 0.2.6
 # Builds the DeepSeek-tailored bundle with its bridge and online setup entry.
-.\scripts\package-micro.ps1 -Version 0.2.5 -Preset deepseek
+.\scripts\package-micro.ps1 -Version 0.2.6 -Preset deepseek
 ```
 
 Outputs:
 
-- single-file executable: `.artifacts/micro-release/0.2.5/publish/CodexMicro.exe`;
-- standalone archive: `dist/CodexMicro-Keypad-0.2.5-win-x64.zip`;
+- single-file executable: `.artifacts/micro-release/0.2.6/publish/CodexMicro.exe`;
+- standalone archive: `dist/CodexMicro-Keypad-0.2.6-win-x64.zip`;
 - SHA-256: adjacent `.sha256` file.
-- DeepSeek bundle: `dist/Deepseek-Harness-Keypad-v0.2.5-win-x64.zip`;
+- DeepSeek bundle: `dist/Deepseek-Harness-Keypad-v0.2.6-win-x64.zip`;
 - standalone existing-DSH plugin:
-  `dist/Deepseek-Harness-Keypad-Bridge-v0.2.5.zip`, with its own checksum.
+  `dist/Deepseek-Harness-Keypad-Bridge-v0.2.6.zip`, with its own checksum.
 
 The packaging script includes `CodexMicro.exe`, the READMEs, the first-run
 setup guide, the license, and the keypad-side `voice` launcher/adapter. It does

--- a/virtual-micro/README.zh-CN.md
+++ b/virtual-micro/README.zh-CN.md
@@ -140,19 +140,19 @@ wsl -d Ubuntu -- bash -lc 'python3.12 -m venv "$HOME/.local/share/codex-micro/qw
 
 ```powershell
 dotnet build .\virtual-micro\src\CodexMicro.DesktopHost\CodexMicro.DesktopHost.csproj -c Release
-.\scripts\package-micro.ps1 -Version 0.2.5
+.\scripts\package-micro.ps1 -Version 0.2.6
 # 准备带桥接插件和在线自动配置入口的 DeepSeek 特调包
-.\scripts\package-micro.ps1 -Version 0.2.5 -Preset deepseek
+.\scripts\package-micro.ps1 -Version 0.2.6 -Preset deepseek
 ```
 
 产物：
 
-- 单文件可执行程序：`.artifacts/micro-release/0.2.5/publish/CodexMicro.exe`；
-- 独立压缩包：`dist/CodexMicro-Keypad-0.2.5-win-x64.zip`；
+- 单文件可执行程序：`.artifacts/micro-release/0.2.6/publish/CodexMicro.exe`；
+- 独立压缩包：`dist/CodexMicro-Keypad-0.2.6-win-x64.zip`；
 - SHA-256：同名 `.sha256` 文件。
-- DeepSeek 特调包：`dist/Deepseek-Harness-Keypad-v0.2.5-win-x64.zip`；
+- DeepSeek 特调包：`dist/Deepseek-Harness-Keypad-v0.2.6-win-x64.zip`；
 - 可单独安装到已有 DSH 的 Bridge：
-  `dist/Deepseek-Harness-Keypad-Bridge-v0.2.5.zip`（也带独立 SHA-256）。
+  `dist/Deepseek-Harness-Keypad-Bridge-v0.2.6.zip`（也带独立 SHA-256）。
 
 封包脚本收录 `CodexMicro.exe`、README、首次配置文档、许可证和小键盘端 `voice`
 启动适配器，不复制模型、Python 环境、Desktop Runtime、调试符号或驱动。

--- a/virtual-micro/src/CodexMicro.Desktop/Services/DeepSeekSurfaceLauncher.cs
+++ b/virtual-micro/src/CodexMicro.Desktop/Services/DeepSeekSurfaceLauncher.cs
@@ -1,0 +1,130 @@
+using System.ComponentModel;
+using System.Diagnostics;
+using System.IO;
+
+namespace CodexMicro.Desktop.Services;
+
+internal readonly record struct DeepSeekSurfaceLaunchResult(
+    bool Started,
+    int? ProcessId,
+    string? Error);
+
+/// <summary>
+/// Opens the DeepSeek web UI as a dedicated native Windows app-mode window.
+/// The Harness host can run inside WSL, but WSL interop is not guaranteed to
+/// be registered or enabled. The Windows Micro host is therefore the
+/// authoritative launcher for a physical DeepSeek-key gesture.
+/// </summary>
+internal static class DeepSeekSurfaceLauncher
+{
+    private const string SurfaceQuery = "codexMicroSurface=1";
+
+    internal static DeepSeekSurfaceLaunchResult TryLaunch(
+        MicroHarnessDefinition harness)
+    {
+        ArgumentNullException.ThrowIfNull(harness);
+        if (!OperatingSystem.IsWindows())
+        {
+            return new(false, null, "Dedicated DeepSeek launch requires Windows.");
+        }
+
+        var browser = FindAppBrowser();
+        if (browser is null)
+        {
+            return new(
+                false,
+                null,
+                "Microsoft Edge or Google Chrome app mode is unavailable.");
+        }
+
+        try
+        {
+            using var process = Process.Start(CreateStartInfo(
+                browser,
+                BuildSurfaceUri(harness)));
+            return process is null
+                ? new(false, null, "The dedicated DeepSeek window did not start.")
+                : new(true, process.Id, null);
+        }
+        catch (Exception exception) when (
+            exception is Win32Exception or
+                InvalidOperationException or
+                IOException or
+                UnauthorizedAccessException)
+        {
+            return new(
+                false,
+                null,
+                $"The dedicated DeepSeek window could not start ({exception.GetType().Name}).");
+        }
+    }
+
+    internal static Uri BuildSurfaceUri(MicroHarnessDefinition harness)
+    {
+        ArgumentNullException.ThrowIfNull(harness);
+        var webUri = Uri.TryCreate(
+                harness.ControlUri,
+                UriKind.Absolute,
+                out var controlUri) &&
+            controlUri.Scheme == Uri.UriSchemeHttp &&
+            controlUri.IsLoopback &&
+            string.IsNullOrEmpty(controlUri.UserInfo)
+                ? controlUri
+                : new Uri(MicroHarnessRegistry.DeepSeekOfficialWebUri);
+        return new UriBuilder(webUri)
+        {
+            Path = "/",
+            Query = SurfaceQuery,
+            Fragment = string.Empty,
+        }.Uri;
+    }
+
+    internal static ProcessStartInfo CreateStartInfo(
+        string browser,
+        Uri surfaceUri)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(browser);
+        ArgumentNullException.ThrowIfNull(surfaceUri);
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = browser,
+            UseShellExecute = false,
+            CreateNoWindow = false,
+            WindowStyle = ProcessWindowStyle.Normal,
+        };
+        startInfo.ArgumentList.Add($"--app={surfaceUri.AbsoluteUri}");
+        startInfo.ArgumentList.Add("--no-first-run");
+        startInfo.ArgumentList.Add("--no-default-browser-check");
+        return startInfo;
+    }
+
+    private static string? FindAppBrowser()
+    {
+        var programFilesX86 = Environment.GetFolderPath(
+            Environment.SpecialFolder.ProgramFilesX86);
+        var programFiles = Environment.GetFolderPath(
+            Environment.SpecialFolder.ProgramFiles);
+        var localAppData = Environment.GetFolderPath(
+            Environment.SpecialFolder.LocalApplicationData);
+        // Preserve the product contract: Edge is the dedicated DeepSeek host;
+        // Chrome is only a compatibility fallback when Edge is unavailable.
+        var candidates = new[]
+        {
+            Combine(programFilesX86, "Microsoft", "Edge", "Application", "msedge.exe"),
+            Combine(programFiles, "Microsoft", "Edge", "Application", "msedge.exe"),
+            Combine(localAppData, "Microsoft", "Edge", "Application", "msedge.exe"),
+            Combine(programFiles, "Google", "Chrome", "Application", "chrome.exe"),
+            Combine(programFilesX86, "Google", "Chrome", "Application", "chrome.exe"),
+            Combine(localAppData, "Google", "Chrome", "Application", "chrome.exe"),
+        };
+        return candidates
+            .Where(path => path is not null)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .FirstOrDefault(File.Exists);
+    }
+
+    private static string? Combine(string root, params string[] parts) =>
+        string.IsNullOrWhiteSpace(root)
+            ? null
+            : Path.Combine([root, .. parts]);
+}

--- a/virtual-micro/src/CodexMicro.Desktop/Services/HarnessWindowActivator.cs
+++ b/virtual-micro/src/CodexMicro.Desktop/Services/HarnessWindowActivator.cs
@@ -32,7 +32,10 @@ internal static class HarnessWindowActivator
             return false;
         }
 
-        return FindCandidates(TitleFragments(harness), preferredProcessId)
+        return FindCandidates(
+                TitleFragments(harness),
+                preferredProcessId,
+                RequiresDedicatedAppWindow(harness))
             .Any(candidate => candidate.Handle == foreground);
     }
 
@@ -42,7 +45,8 @@ internal static class HarnessWindowActivator
     {
         var candidate = FindCandidates(
                 TitleFragments(harness),
-                preferredProcessId)
+                preferredProcessId,
+                RequiresDedicatedAppWindow(harness))
             .OrderByDescending(item => item.Score)
             .FirstOrDefault();
         if (candidate.Handle == IntPtr.Zero)
@@ -124,7 +128,8 @@ internal static class HarnessWindowActivator
 
     private static IEnumerable<WindowCandidate> FindCandidates(
         IReadOnlyList<string> titleFragments,
-        int? preferredProcessId)
+        int? preferredProcessId,
+        bool dedicatedAppOnly)
     {
         var candidates = new List<WindowCandidate>();
         _ = EnumWindows((handle, state) =>
@@ -145,6 +150,10 @@ internal static class HarnessWindowActivator
                 Math.Max(GetWindowTextLength(handle) + 1, 2));
             _ = GetWindowText(handle, title, title.Capacity);
             var text = title.ToString();
+            if (dedicatedAppOnly && !IsDedicatedBrowserWindowTitle(text))
+            {
+                return true;
+            }
             var isPreferredProcess = preferredProcessId is > 0 &&
                 processId == (uint)preferredProcessId.Value;
             var hasPrimaryTitle = titleFragments.Count > 0 &&
@@ -183,6 +192,20 @@ internal static class HarnessWindowActivator
             return true;
         }, IntPtr.Zero);
         return candidates;
+    }
+
+    private static bool RequiresDedicatedAppWindow(
+        MicroHarnessDefinition harness) =>
+        harness.Id.Contains("deepseek", StringComparison.OrdinalIgnoreCase);
+
+    internal static bool IsDedicatedBrowserWindowTitle(string title)
+    {
+        ArgumentNullException.ThrowIfNull(title);
+        return !title.Contains(" - Google Chrome", StringComparison.OrdinalIgnoreCase) &&
+            !title.Contains(" - Microsoft Edge", StringComparison.OrdinalIgnoreCase) &&
+            !title.Contains(" - Brave", StringComparison.OrdinalIgnoreCase) &&
+            !title.Contains(" - Vivaldi", StringComparison.OrdinalIgnoreCase) &&
+            !title.Contains(" — Mozilla Firefox", StringComparison.OrdinalIgnoreCase);
     }
 
     private static bool IsSupportedBrowser(uint processId)

--- a/virtual-micro/src/CodexMicro.Desktop/Services/MicroHarnessRegistry.cs
+++ b/virtual-micro/src/CodexMicro.Desktop/Services/MicroHarnessRegistry.cs
@@ -298,6 +298,9 @@ internal sealed class MicroHarnessRegistry
     private IReadOnlyList<MicroHarnessDefinition> _definitions;
     private Dictionary<string, MicroHarnessKeyMap> _keyMaps;
     private readonly Dictionary<string, string> _knobModes;
+    private readonly Func<
+        MicroHarnessDefinition,
+        DeepSeekSurfaceLaunchResult> _surfaceLauncher;
     private readonly HashSet<string> _setupCompleted;
     private readonly Dictionary<string, MicroHarnessTimeoutDiagnostic>
         _lastTimeouts;
@@ -305,8 +308,11 @@ internal sealed class MicroHarnessRegistry
     internal MicroHarnessRegistry(
         IEnumerable<MicroHarnessDefinition>? definitions = null,
         string? manifestDirectory = null,
-        string? settingsPath = null)
+        string? settingsPath = null,
+        Func<MicroHarnessDefinition, DeepSeekSurfaceLaunchResult>?
+            surfaceLauncher = null)
     {
+        _surfaceLauncher = surfaceLauncher ?? DeepSeekSurfaceLauncher.TryLaunch;
         _settingsPath = settingsPath ?? GetDefaultSettingsPath();
         _diagnosticsPath = GetDiagnosticsPath(_settingsPath);
         _lastTimeouts = ReadTimeoutDiagnostics(_diagnosticsPath);
@@ -644,6 +650,24 @@ internal sealed class MicroHarnessRegistry
             return result with { Step = 5, TotalSteps = 7 };
         }
 
+        DeepSeekSurfaceLaunchResult? surfaceLaunch = null;
+        var surfaceProcessId = result.WindowProcessId;
+        if (string.Equals(
+                harness.Id,
+                "deepseek-harness",
+                StringComparison.OrdinalIgnoreCase) &&
+            result.WindowProcessId is null)
+        {
+            surfaceLaunch = _surfaceLauncher(harness);
+            surfaceProcessId = surfaceLaunch.Value.ProcessId ?? surfaceProcessId;
+            Report(new(
+                MicroHarnessDispatchStage.Opening,
+                surfaceLaunch.Value.Started
+                    ? "Opening the dedicated DeepSeek app window on Windows."
+                    : "Waiting for the dedicated DeepSeek window after its Windows launcher failed."),
+                4);
+        }
+
         Report(new(
             MicroHarnessDispatchStage.Opening,
             $"Waiting for {harness.DisplayName} browser surface."), 5);
@@ -664,7 +688,12 @@ internal sealed class MicroHarnessRegistry
                 continue;
             }
 
-            result = ToDispatchResult(exchange);
+            var exchangeResult = ToDispatchResult(exchange);
+            result = exchangeResult with
+            {
+                WindowProcessId = exchangeResult.WindowProcessId ??
+                    surfaceProcessId,
+            };
             if (!result.Success ||
                 result.Stage != MicroHarnessDispatchStage.Opening)
             {
@@ -678,7 +707,15 @@ internal sealed class MicroHarnessRegistry
             }
         }
 
-        return result with { Step = 5, TotalSteps = 7 };
+        return result with
+        {
+            Message = surfaceLaunch is { Started: false, Error: not null }
+                ? $"{result.Message} {surfaceLaunch.Value.Error}"
+                : result.Message,
+            WindowProcessId = result.WindowProcessId ?? surfaceProcessId,
+            Step = 5,
+            TotalSteps = 7,
+        };
     }
 
     internal Task<MicroHarnessDispatchResult> ActivateSessionAsync(

--- a/virtual-micro/src/CodexMicro.DesktopHost/CodexMicro.DesktopHost.csproj
+++ b/virtual-micro/src/CodexMicro.DesktopHost/CodexMicro.DesktopHost.csproj
@@ -15,9 +15,9 @@
     <AssemblyTitle>Codex Micro Keypad</AssemblyTitle>
     <Product>Codex Micro Keypad</Product>
     <Description>Standalone Codex Micro keypad using the original WPF XAML.</Description>
-    <Version>0.2.5</Version>
-    <AssemblyVersion>0.2.5.0</AssemblyVersion>
-    <FileVersion>0.2.5.0</FileVersion>
+    <Version>0.2.6</Version>
+    <AssemblyVersion>0.2.6.0</AssemblyVersion>
+    <FileVersion>0.2.6.0</FileVersion>
     <ApplicationIcon>..\..\Assets\CodexMicro.ico</ApplicationIcon>
   </PropertyGroup>
 

--- a/virtual-micro/src/DeepSeekKeypad.OneClick/DeepSeekKeypad.OneClick.csproj
+++ b/virtual-micro/src/DeepSeekKeypad.OneClick/DeepSeekKeypad.OneClick.csproj
@@ -16,9 +16,9 @@
     <AssemblyTitle>Deepseek Harness Keypad OneClick</AssemblyTitle>
     <Product>Deepseek Harness Keypad</Product>
     <Description>Per-user one-click installer for Deepseek Harness Keypad.</Description>
-    <Version>0.2.5</Version>
-    <AssemblyVersion>0.2.5.0</AssemblyVersion>
-    <FileVersion>0.2.5.0</FileVersion>
+    <Version>0.2.6</Version>
+    <AssemblyVersion>0.2.6.0</AssemblyVersion>
+    <FileVersion>0.2.6.0</FileVersion>
     <ApplicationIcon>..\..\Assets\CodexMicro.ico</ApplicationIcon>
   </PropertyGroup>
 

--- a/virtual-micro/src/DeepSeekKeypad.OneClick/Program.cs
+++ b/virtual-micro/src/DeepSeekKeypad.OneClick/Program.cs
@@ -69,7 +69,7 @@ internal sealed record InstallerOptions(
 internal sealed class InstallerForm : Form
 {
     private const string ProductId = "deepseek-harness-keypad";
-    private const string ReleaseVersion = "0.2.5";
+    private const string ReleaseVersion = "0.2.6";
     private const string InstallDirectoryName = "Deepseek Harness Keypad";
     private const string ExecutableName = "CodexMicro.exe";
     private const string MarkerName = ".deepseek-harness-keypad.install.json";

--- a/virtual-micro/tests/CodexMicro.Desktop.Tests/DeepSeekSurfaceLauncherTests.cs
+++ b/virtual-micro/tests/CodexMicro.Desktop.Tests/DeepSeekSurfaceLauncherTests.cs
@@ -1,0 +1,42 @@
+using CodexMicro.Desktop.Services;
+using System.Diagnostics;
+using Xunit;
+
+namespace CodexMicro.Desktop.Tests;
+
+public sealed class DeepSeekSurfaceLauncherTests
+{
+    [Fact]
+    public void BuildsAnAppModeUrlFromTheConfiguredControlEndpoint()
+    {
+        var harness = new MicroHarnessDefinition(
+            "deepseek-harness",
+            "DeepSeek Harness",
+            "Test Harness",
+            null,
+            true,
+            new(
+                null,
+                null,
+                null,
+                null,
+                false,
+                ControlUri:
+                    "http://127.0.0.1:3097/__agentcontroller/micro/request"));
+
+        var surfaceUri = DeepSeekSurfaceLauncher.BuildSurfaceUri(harness);
+        var startInfo = DeepSeekSurfaceLauncher.CreateStartInfo(
+            @"C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe",
+            surfaceUri);
+
+        Assert.Equal(
+            "http://127.0.0.1:3097/?codexMicroSurface=1",
+            surfaceUri.AbsoluteUri);
+        Assert.False(startInfo.UseShellExecute);
+        Assert.False(startInfo.CreateNoWindow);
+        Assert.Equal(ProcessWindowStyle.Normal, startInfo.WindowStyle);
+        Assert.Contains(
+            "--app=http://127.0.0.1:3097/?codexMicroSurface=1",
+            startInfo.ArgumentList);
+    }
+}

--- a/virtual-micro/tests/CodexMicro.Desktop.Tests/HarnessWindowActivatorTests.cs
+++ b/virtual-micro/tests/CodexMicro.Desktop.Tests/HarnessWindowActivatorTests.cs
@@ -12,4 +12,18 @@ public sealed class HarnessWindowActivatorTests
             IntPtr.Zero,
             HarnessWindowActivator.ActivationFallbackInsertAfter);
     }
+
+    [Theory]
+    [InlineData("Windows录屏软件与脚本方案 — DeepSeek Harness", true)]
+    [InlineData("DeepSeek Harness - Google Chrome", false)]
+    [InlineData("DeepSeek Harness - Microsoft Edge", false)]
+    [InlineData("DeepSeek Harness - Personal - Microsoft Edge", false)]
+    public void DeepSeekActivationRejectsNormalBrowserChrome(
+        string title,
+        bool expected)
+    {
+        Assert.Equal(
+            expected,
+            HarnessWindowActivator.IsDedicatedBrowserWindowTitle(title));
+    }
 }

--- a/virtual-micro/tests/CodexMicro.Desktop.Tests/MicroHarnessRegistryTests.cs
+++ b/virtual-micro/tests/CodexMicro.Desktop.Tests/MicroHarnessRegistryTests.cs
@@ -968,6 +968,76 @@ public sealed class MicroHarnessRegistryTests
             item is { Step: 5, TotalSteps: 7 });
     }
 
+    [Theory]
+    [InlineData(false, 1, 6_789)]
+    [InlineData(true, 0, 4_321)]
+    public async Task DeepSeekActivationOwnsExactlyOneWindowsSurfaceLaunch(
+        bool adapterAlreadyLaunched,
+        int expectedLaunches,
+        int expectedProcessId)
+    {
+        var pipeName = $"codex-micro-deepseek-surface-{Guid.NewGuid():N}";
+        var definition = new MicroHarnessDefinition(
+            "deepseek-harness",
+            "DeepSeek Harness",
+            "Test direct adapter",
+            null,
+            true,
+            new(pipeName, null, null, null, false));
+        var launches = new List<MicroHarnessDefinition>();
+        var registry = new MicroHarnessRegistry(
+            [definition],
+            settingsPath: Path.Combine(
+                Path.GetTempPath(),
+                $"missing-{Guid.NewGuid():N}",
+                "settings.json"),
+            surfaceLauncher: harness =>
+            {
+                launches.Add(harness);
+                return new(true, 6_789, null);
+            });
+        var serverTask = Task.Run(async () =>
+        {
+            for (var attempt = 0; attempt < 2; attempt++)
+            {
+                await using var server = new NamedPipeServerStream(
+                    pipeName,
+                    PipeDirection.InOut,
+                    1,
+                    PipeTransmissionMode.Byte,
+                    PipeOptions.Asynchronous);
+                await server.WaitForConnectionAsync();
+                using var reader = new StreamReader(
+                    server,
+                    Encoding.UTF8,
+                    leaveOpen: true);
+                await using var writer = new StreamWriter(
+                    server,
+                    new UTF8Encoding(false),
+                    leaveOpen: true)
+                {
+                    AutoFlush = true,
+                };
+                _ = await reader.ReadLineAsync();
+                await writer.WriteLineAsync(attempt == 0
+                    ? adapterAlreadyLaunched
+                        ? "{\"success\":true,\"message\":\"opening dedicated window\",\"status\":\"opening\",\"windowProcessId\":4321}"
+                        : "{\"success\":true,\"message\":\"opening dedicated window\",\"status\":\"opening\"}"
+                    : "{\"success\":true,\"message\":\"dedicated surface connected\",\"status\":\"background\"}");
+            }
+        });
+
+        var result = await registry.ActivateUntilSurfaceReadyAsync(definition.Id);
+        await serverTask;
+
+        Assert.True(result.Success, result.Message);
+        Assert.Equal(MicroHarnessDispatchStage.Background, result.Stage);
+        Assert.Equal(expectedProcessId, result.WindowProcessId);
+        Assert.Equal(expectedLaunches, launches.Count);
+        Assert.All(launches, launched =>
+            Assert.Equal(definition.Id, launched.Id));
+    }
+
     [Fact]
     public async Task ColdStartProbesReadinessBeforeDispatchingActivation()
     {


### PR DESCRIPTION
## What changed

- route physical DeepSeek-key activation, session actions, and dictation only to a confirmed dedicated surface
- launch the dedicated surface from the Windows host with Edge first and Chrome only as fallback
- reject normal browser-chrome windows during native HWND activation
- synchronize browser-observed running state to both the detailed Agent-light status and legacy running bit
- add loopback HTTP/SSE E2E coverage for tab interception, Agent-light synchronization, and reconnect races
- bump the keypad, Bridge, one-click installers, packaging defaults, and release notes to v0.2.6

## Root cause

A focused normal browser tab could outscore the dedicated surface, while WSL executable interop failure prevented Edge app-mode startup. The Windows title matcher also accepted ordinary browser windows. Separately, a dedicated browser could report a running turn while the bridge retained the stale host `running=false` bit, leaving the Agent key unlit.

## Impact

The DeepSeek key now consistently opens and focuses an Edge app-mode surface. Normal Chrome or Edge tabs cannot steal keypad events, and the Agent key reflects a running turn immediately. Existing Qwen3-ASR single-instance and state-completion fixes remain intact.

## Validation

- DeepSeek Bridge: 31/31 tests, including 3 loopback HTTP/SSE E2E cases
- .NET solution: 1021/1021 tests
- live Edge app-mode launch, activation, and native foreground verification
- live DSH state endpoint: adapter ready / browser connected
- live Qwen3-ASR health: ready / dsh-stream-v1
- clean Ubuntu 24.04 WSL payload build, rootfs security audit, strict offline re-import, and runtime probe
- both one-click embedded payloads verified
- all four release assets independently rehashed against adjacent SHA-256 files
